### PR TITLE
Addition of flag, fixes for tStepR

### DIFF
--- a/polarCoordinateTraversal.m
+++ b/polarCoordinateTraversal.m
@@ -187,7 +187,7 @@ while (t < t_end)
         end
     end
     
-    angular_voxels = [angular_voxels, current_voxel_ID_theta]
-    radial_voxels = [radial_voxels, current_voxel_ID_r]
+    angular_voxels = [angular_voxels, current_voxel_ID_theta];
+    radial_voxels = [radial_voxels, current_voxel_ID_r];
 end
 end

--- a/radial_hit.m
+++ b/radial_hit.m
@@ -1,5 +1,5 @@
-function[tMaxR, tStepR]=radial_hit(ray_origin, ray_direction, current_radial_voxel, ...
-        circle_center, circle_max_radius, delta_radius, r, t, verbose)
+function[tMaxR, tStepR, transitionFlag]=radial_hit(ray_origin, ray_direction, current_radial_voxel, ...
+        circle_center, circle_max_radius, delta_radius, t, prev_transitionFlag, verbose)
 % Determines whether a radial hit occurs for the given ray.
 % Input:
 %    ray_origin: The origin of the ray.
@@ -18,20 +18,29 @@ if verbose
     fprintf('\n--radial_hit-- \nCurrent Radial Voxel: %d', current_radial_voxel)
 end
 
+
 % Recapture the current radius of ray.
-r = circle_max_radius - delta_radius*(current_radial_voxel - 1);
+r = circle_max_radius - delta_radius * (current_radial_voxel - 1);
 
 % Check for intersections with relevant radial neighbors.
+
+% TODO: ray_unit_vector, ray_circle_vector, v can be calculated during
+% initialization phase.
 ray_unit_vector = 1/sqrt(ray_direction(1)^2 + ray_direction(2)^2)...
     .* [ray_direction(1);  ray_direction(2)]';
 ray_circle_vector = [circle_center(1) - ray_origin(1); circle_center(2) - ray_origin(2)]';
 v = dot(ray_circle_vector,ray_unit_vector);
+t
 r_a = max(r - delta_radius , delta_radius);
+% In the case that the ray has sequential hits with equal radii ensure that proper radii are
+% being checked: without this, code skips ahead one radial boundary.
+if prev_transitionFlag
+r_b = min(r, circle_max_radius);
+else
 r_b = min(r + delta_radius, circle_max_radius);
-tol = 10^-10;
-if (abs(r_a - r_b) < tol)
-    r_b = r + 2 * delta_radius;
 end
+
+tol = 10^-10;
 
 time_array_a = [];
 time_array_b = [];
@@ -47,7 +56,7 @@ if (discr >= 0 )
     time_array_a(1) = t1;
     time_array_a(2) = t2;
 else
-    r_a = r_a + delta_radius;
+    r_a = r_a + delta_radius
     discr = r_a^2 - (dot(ray_circle_vector,ray_circle_vector) - v^2);
     d = sqrt(discr);
     ta = (v-d);
@@ -72,12 +81,13 @@ if (discr >= 0 )
     time_array_b(1) = t1;
     time_array_b(2) = t2;
 end
-time_array = [time_array_a time_array_b];
-time = time_array(time_array > t);
-
+time_array = [time_array_a time_array_b]
+time = time_array(time_array > t)
+pause
 if (isempty(time))
     tMaxR = inf;
-    tStepR = -1;
+    tStepR = 0;
+    transitionFlag = false;
     if verbose
         fprintf("\nNo intersection for a radial hit for current r: %d", r);
     end
@@ -85,15 +95,21 @@ if (isempty(time))
 end
 tMaxR = time(1);
 p = ray_origin + tMaxR.*ray_direction;
-r_new = sqrt((p(1) - circle_center(1))^2 + (p(2) - circle_center(2))^2);
-if (abs(r_new - r) < tol)
-    tStepR = 0;
-elseif (r_new - r > 0)
-    tStepR = -1;
+r_new = sqrt((p(1) - circle_center(1))^2 + (p(2) - circle_center(2))^2)
+
+%Flag for case that the ray has sequential hits with equal radii.
+if (abs(r - r_new) < tol)
+    transitionFlag = true;
 else
-    tStepR = 1;
+    transitionFlag = false;
 end
- 
+
+if (r_new - r < 0 && abs(r_new - r) > tol) 
+    tStepR = 1;
+else
+    tStepR = -1;
+end
+pause
 if verbose
     fprintf('\ntMaxR: %d \n', tMaxR);
 end

--- a/radial_hit.m
+++ b/radial_hit.m
@@ -18,19 +18,16 @@ if verbose
     fprintf('\n--radial_hit-- \nCurrent Radial Voxel: %d', current_radial_voxel)
 end
 
-
 % Recapture the current radius of ray.
 r = circle_max_radius - delta_radius * (current_radial_voxel - 1);
 
 % Check for intersections with relevant radial neighbors.
-
 % TODO: ray_unit_vector, ray_circle_vector, v can be calculated during
 % initialization phase.
 ray_unit_vector = 1/sqrt(ray_direction(1)^2 + ray_direction(2)^2)...
     .* [ray_direction(1);  ray_direction(2)]';
 ray_circle_vector = [circle_center(1) - ray_origin(1); circle_center(2) - ray_origin(2)]';
 v = dot(ray_circle_vector,ray_unit_vector);
-t
 r_a = max(r - delta_radius , delta_radius);
 % In the case that the ray has sequential hits with equal radii ensure that proper radii are
 % being checked: without this, code skips ahead one radial boundary.
@@ -56,7 +53,7 @@ if (discr >= 0 )
     time_array_a(1) = t1;
     time_array_a(2) = t2;
 else
-    r_a = r_a + delta_radius
+    r_a = r_a + delta_radius;
     discr = r_a^2 - (dot(ray_circle_vector,ray_circle_vector) - v^2);
     d = sqrt(discr);
     ta = (v-d);
@@ -81,9 +78,8 @@ if (discr >= 0 )
     time_array_b(1) = t1;
     time_array_b(2) = t2;
 end
-time_array = [time_array_a time_array_b]
-time = time_array(time_array > t)
-pause
+time_array = [time_array_a time_array_b];
+time = time_array(time_array > t);
 if (isempty(time))
     tMaxR = inf;
     tStepR = 0;
@@ -95,7 +91,7 @@ if (isempty(time))
 end
 tMaxR = time(1);
 p = ray_origin + tMaxR.*ray_direction;
-r_new = sqrt((p(1) - circle_center(1))^2 + (p(2) - circle_center(2))^2)
+r_new = sqrt((p(1) - circle_center(1))^2 + (p(2) - circle_center(2))^2);
 
 %Flag for case that the ray has sequential hits with equal radii.
 if (abs(r - r_new) < tol)
@@ -109,7 +105,6 @@ if (r_new - r < 0 && abs(r_new - r) > tol)
 else
     tStepR = -1;
 end
-pause
 if verbose
     fprintf('\ntMaxR: %d \n', tMaxR);
 end


### PR DESCRIPTION
Addition off flag for the case when the ray passes through, sequentially, two radial boundaries of equal radius. Previously, this case caused a skip ahead in te radial hit check. Also, fix to tStepR block.