### PR TITLE
Code clean-up, initialization outside of hot loop, fix early exit.

### DIFF
--- a/polarCoordinateTraversal.m
+++ b/polarCoordinateTraversal.m
@@ -161,7 +161,6 @@ while (t < t_end)
     % 1. Calculate tMaxR, tMaxTheta
     [tMaxR, tStepR, previous_transition_flag] = radial_hit(ray_origin, ray_direction, ...
         current_voxel_ID_r, circle_center, circle_max_radius, delta_radius, t, ray_unit_vector, ray_circle_vector, v, previous_transition_flag, verbose);
-        if (current_voxel_ID_r + tStepR <= 0), return; end
     [tMaxTheta, tStepTheta] = angular_hit(ray_origin, ray_direction, current_voxel_ID_theta,...
         num_angular_sections, circle_center, t, verbose);
     
@@ -179,6 +178,7 @@ while (t < t_end)
     else
         t = tMaxR;
         current_voxel_ID_r = current_voxel_ID_r + tStepR;
+        if (current_voxel_ID_r <= 0), return; end
 
         if verbose
           new_x_position = ray_origin_x + ray_direction_x * tMaxR;

--- a/polarCoordinateTraversal.m
+++ b/polarCoordinateTraversal.m
@@ -137,30 +137,39 @@ if verbose
     fprintf('RADIAL HIT INITIALIZED.\n');
 end
 
-% II. Calculate Voxel ID Theta.
+% Calculate Voxel ID Theta.
 current_voxel_ID_theta = floor(atan2(ray_start_y - circle_center_y, ray_start_x - circle_center_x) * num_angular_sections / (2 * pi));
 if current_voxel_ID_theta < 0
     current_voxel_ID_theta = num_angular_sections + current_voxel_ID_theta;
 end
 
+% Pre-calculations for radial_hit. This is necessary to check for intersections with relevant radial neighbors.
+ray_unit_vector = 1 / sqrt(ray_direction(1)^2 + ray_direction(2)^2)...
+    .* [ray_direction(1);  ray_direction(2)]';
+ray_circle_vector = [circle_center(1) - ray_origin(1); circle_center(2) - ray_origin(2)]';
+v = dot(ray_circle_vector,ray_unit_vector);
+
+
 angular_voxels = [current_voxel_ID_theta];
 radial_voxels = [current_voxel_ID_r];
 
-% III. TRAVERSAL PHASE
+% TRAVERSAL PHASE
 t = t_begin; 
 previous_transition_flag = false;
+
 while (t < t_end)
     % 1. Calculate tMaxR, tMaxTheta
     [tMaxR, tStepR, previous_transition_flag] = radial_hit(ray_origin, ray_direction, ...
-        current_voxel_ID_r, circle_center, circle_max_radius, delta_radius, t, previous_transition_flag, verbose);
+        current_voxel_ID_r, circle_center, circle_max_radius, delta_radius, t, ray_unit_vector, ray_circle_vector, v, previous_transition_flag, verbose);
         if (current_voxel_ID_r + tStepR <= 0), return; end
     [tMaxTheta, tStepTheta] = angular_hit(ray_origin, ray_direction, current_voxel_ID_theta,...
-        num_angular_sections, circle_center, t, false);
-    if (current_voxel_ID_r + tStepR == 0), return; end
+        num_angular_sections, circle_center, t, verbose);
+    
     % 2. Compare tMaxTheta, tMaxR
     if (tMaxTheta < tMaxR)
         t = tMaxTheta;
         current_voxel_ID_theta = current_voxel_ID_theta + tStepTheta;
+        
         if verbose
             new_x_position = ray_origin(1) + ray_direction(1) * tMaxTheta;
             new_y_position = ray_origin(2) + ray_direction(2) * tMaxTheta;
@@ -169,10 +178,7 @@ while (t < t_end)
         end
     else
         t = tMaxR;
-        p = ray_origin + t.*ray_direction;
-        r_new = sqrt((p(1) - circle_center(1))^2 + (p(2) - circle_center(2))^2);
         current_voxel_ID_r = current_voxel_ID_r + tStepR;
-        r = r_new;
 
         if verbose
           new_x_position = ray_origin_x + ray_direction_x * tMaxR;


### PR DESCRIPTION
- Code cleanup for ```polarCoordinateTraversal```, ```radial_hit```.
- Anything that can be initialized outside of ```radial_hit``` has been moved.
- I've changed the location of ``` if (current_voxel_ID_r + tStepR <= 0), return; end```. Before, this was going to exit early even if the next step was not a radial step. This should only occur IF the next step is a radial step.
- Added documentation for new arguments.