### PR TITLE
Add simple spherical traversal tests.

### DIFF
--- a/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
+++ b/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
@@ -54,3 +54,26 @@ function testSphereCenteredAtOrigin(testCase)
     verifyEqual(testCase, thetaVoxels, [2,2,2,2,0,0,0,0]);
     verifyEqual(testCase, phiVoxels, [2,2,2,2,0,0,0,0]);
 end
+
+% Change direction of ray slightly in the XY plane.
+function testRayChangesinXYPlane(testCase)
+    min_bound = [-20, -20.0, -20.0];
+    max_bound = [20.0, 20.0, 20.0];
+    ray_origin = [-13.0, -13.0, -13.0];
+    ray_direction = [1.0, 1.5, 1.0];
+    sphere_center = [0.0, 0.0, 0.0];
+    sphere_max_radius = 10.0;
+    
+    num_radial_sections = 4;
+    num_angular_sections = 4;
+    num_azimuthal_sections = 4;
+    t_begin = 0.0;
+    t_end = 30.0;
+    verbose = false;
+    
+    [rVoxels, thetaVoxels, phiVoxels] = sphericalCoordinateTraversal(min_bound, max_bound, ray_origin, ray_direction, ...
+    sphere_center, sphere_max_radius, num_radial_sections, num_angular_sections, num_azimuthal_sections, t_begin, t_end, verbose);
+    verifyEqual(testCase, rVoxels, [1,2,2,3,2,2,2,1]);
+    verifyEqual(testCase, thetaVoxels, [2,2,1,1,1,1,0,0]);
+    verifyEqual(testCase, phiVoxels, [2,2,2,2,2,0,0,0]);
+end

--- a/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
+++ b/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
@@ -56,7 +56,7 @@ function testSphereCenteredAtOrigin(testCase)
 end
 
 % Change direction of ray slightly in the XY plane.
-function testRayChangesinXYPlane(testCase)
+function testRayOffsetinXYPlane(testCase)
     min_bound = [-20, -20.0, -20.0];
     max_bound = [20.0, 20.0, 20.0];
     ray_origin = [-13.0, -13.0, -13.0];

--- a/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
+++ b/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
@@ -56,7 +56,7 @@ function testSphereCenteredAtOrigin(testCase)
 end
 
 % Change direction of ray slightly in the XY plane.
-function testRayOffsetinXYPlane(testCase)
+function testRayOffsetInXYPlane(testCase)
     min_bound = [-20, -20.0, -20.0];
     max_bound = [20.0, 20.0, 20.0];
     ray_origin = [-13.0, -13.0, -13.0];

--- a/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
+++ b/matlab/spherical-traversal/sphericalCoordinateTraversalTest.m
@@ -77,3 +77,49 @@ function testRayOffsetInXYPlane(testCase)
     verifyEqual(testCase, thetaVoxels, [2,2,1,1,1,1,0,0]);
     verifyEqual(testCase, phiVoxels, [2,2,2,2,2,0,0,0]);
 end
+
+% Ray parallel to the XY Plane.
+function testRayParallelToXYPlane(testCase)
+    min_bound = [-20, -20.0, -20.0];
+    max_bound = [20.0, 20.0, 20.0];
+    ray_origin = [-15.0, -15.0, 0.0];
+    ray_direction = [1.0, 1.0, 0.0];
+    sphere_center = [0.0, 0.0, 0.0];
+    sphere_max_radius = 10.0;
+    
+    num_radial_sections = 4;
+    num_angular_sections = 4;
+    num_azimuthal_sections = 4;
+    t_begin = 0.0;
+    t_end = 30.0;
+    verbose = false;
+    
+    [rVoxels, thetaVoxels, phiVoxels] = sphericalCoordinateTraversal(min_bound, max_bound, ray_origin, ray_direction, ...
+    sphere_center, sphere_max_radius, num_radial_sections, num_angular_sections, num_azimuthal_sections, t_begin, t_end, verbose);
+    verifyEqual(testCase, rVoxels, [1,2,3,4,4,3,2,1]);
+    verifyEqual(testCase, thetaVoxels, [2,2,2,2,0,0,0,0]);
+    verifyEqual(testCase, phiVoxels, [2,2,2,2,0,0,0,0]);
+end
+
+% Ray parallel to the XZ Plane.
+function testRayParallelToXZPlane(testCase)
+    min_bound = [-20, -20.0, -20.0];
+    max_bound = [20.0, 20.0, 20.0];
+    ray_origin = [-15.0, 0.0, -15.0];
+    ray_direction = [1.0, 0.0, 1.0];
+    sphere_center = [0.0, 0.0, 0.0];
+    sphere_max_radius = 10.0;
+    
+    num_radial_sections = 4;
+    num_angular_sections = 4;
+    num_azimuthal_sections = 4;
+    t_begin = 0.0;
+    t_end = 30.0;
+    verbose = false;
+    
+    [rVoxels, thetaVoxels, phiVoxels] = sphericalCoordinateTraversal(min_bound, max_bound, ray_origin, ray_direction, ...
+    sphere_center, sphere_max_radius, num_radial_sections, num_angular_sections, num_azimuthal_sections, t_begin, t_end, verbose);
+    verifyEqual(testCase, rVoxels, [1,2,3,4,4,3,2,1]);
+    verifyEqual(testCase, thetaVoxels, [2,2,2,2,0,0,0,0]);
+    verifyEqual(testCase, phiVoxels, [2,2,2,2,0,0,0,0]);
+end


### PR DESCRIPTION
- Added a test that slightly changes the ray direction in the XY-plane.
- Added two tests, parallel to XY and XZ planes. (**Note**: These may change when the code is updated, since its along an angular boundary).

**Note:** Trying this test in the XZ plane, i.e. ray direction = [1, 1, 1.5] claims that only 5 voxel traversals occur. Its difficult to determine whether this is true or not, even with spherePlot.py. Does this mean the ray is exiting from the top early?