### PR TITLE
Fix cpp version to pass spherical tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /cpp/cython/CythonSVR.cpython-37m-darwin.so
 /cpp/cython/.DS_Store
 /cpp/testing/build/
+/cpp/testing/SVR_debug_code.cpp

--- a/cpp/cython/CythonSVR_test.py
+++ b/cpp/cython/CythonSVR_test.py
@@ -8,7 +8,7 @@ import CythonSVR
 
 class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
     # Verifies correctness of the voxel traversal coordinates.
-    def verifyVoxels(self, voxels, expected_radial_voxels,  expected_theta_voxels,  expected_phi_voxels):
+    def verify_voxels(self, voxels, expected_radial_voxels,  expected_theta_voxels,  expected_phi_voxels):
         i = 0
         actual_radial_voxels = []
         actual_theta_voxels = []
@@ -58,7 +58,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [2,2,2,2,0,0,0,0]
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_direction_travels_along_X_axis(self):
         ray_origin = np.array([-15.0, 0.0, 0.0])
@@ -79,7 +79,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [4,4,4,4,5,5,5,5]
         expected_phi_voxels = [2,2,2,2,3,3,3,3]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_direction_travels_along_Y_axis(self):
         ray_origin = np.array([0.0, -15.0, 0.0])
@@ -100,7 +100,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [6,6,6,6,7,7,7,7]
         expected_phi_voxels = [0,0,0,0,0,0,0,0]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_direction_travels_along_Z_axis(self):
         ray_origin = np.array([0.0, 0.0, -15.0])
@@ -121,7 +121,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [0,0,0,0,0,0,0,0]
         expected_phi_voxels = [3,3,3,3,0,0,0,0]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_parallel_to_XY_plane(self):
         ray_origin = np.array([-15.0, -15.0, 0.0])
@@ -142,7 +142,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
         expected_theta_voxels = [2,2,2,2,0,0,0,0]
         expected_phi_voxels = [2,2,2,2,3,3,3,3]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_parallel_to_XZ_plane(self):
         ray_origin = np.array([-15.0, 0.0, -15.0])
@@ -163,7 +163,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,5,5,4,3,2,1]
         expected_theta_voxels = [2,2,2,2,2,3,3,3,3,3]
         expected_phi_voxels = [2,2,2,2,2,0,0,0,0,0]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
     def test_ray_parallel_to_YZ_plane(self):
         ray_origin = np.array([0.0, -15.0, -15.0])
@@ -184,7 +184,7 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_radial_voxels = [1,2,3,4,5,5,4,3,2,1]
         expected_theta_voxels = [3,3,3,3,3,0,0,0,0,0]
         expected_phi_voxels = [3,3,3,3,3,0,0,0,0,0]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+        self.verify_voxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
 
 if __name__ == '__main__':

--- a/cpp/cython/CythonSVR_test.py
+++ b/cpp/cython/CythonSVR_test.py
@@ -60,36 +60,15 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_phi_voxels = [2,2,2,2,0,0,0,0]
         self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
-    def test_ray_direction_slightly_offset_in_XY_plane(self):
-        ray_origin = np.array([-13.0, -13.0, -13.0])
-        ray_direction = np.array([1.0, 1.5, 1.0])
-        min_bound = np.array([-20.0, -20.0, -20.0])
-        max_bound = np.array([20.0, 20.0, 20.0])
+    def test_ray_direction_travels_along_X_axis(self):
+        ray_origin = np.array([-15.0, 0.0, 0.0])
+        ray_direction = np.array([1.0, 0.0, 0.0])
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([30.0, 30.0, 30.0])
         sphere_center = np.array([0.0, 0.0, 0.0])
         sphere_max_radius = 10.0
         num_radial_sections = 4
-        num_angular_sections = 4
-        num_azimuthal_sections = 4
-        t_begin = 0.0
-        t_end = 30.0
-
-        voxels = CythonSVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
-                                                 num_angular_sections, num_azimuthal_sections, sphere_center,
-                                                 sphere_max_radius, t_begin, t_end)
-        expected_radial_voxels = [1,2,2,3,2,2,2,1]
-        expected_theta_voxels = [2,2,1,1,1,1,0,0]
-        expected_phi_voxels = [2,2,2,2,2,0,0,0]
-        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
-
-    def test_ray_parallel_to_XY_plane(self):
-        ray_origin = np.array([-15.0, -15.0, 0.0])
-        ray_direction = np.array([1.0, 1.0, 0.0])
-        min_bound = np.array([-20.0, -20.0, -20.0])
-        max_bound = np.array([20.0, 20.0, 20.0])
-        sphere_center = np.array([0.0, 0.0, 0.0])
-        sphere_max_radius = 10.0
-        num_radial_sections = 4
-        num_angular_sections = 4
+        num_angular_sections = 8
         num_azimuthal_sections = 4
         t_begin = 0.0
         t_end = 30.0
@@ -98,9 +77,52 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
                                                  num_angular_sections, num_azimuthal_sections, sphere_center,
                                                  sphere_max_radius, t_begin, t_end)
         expected_radial_voxels = [1,2,3,4,4,3,2,1]
-        expected_theta_voxels = [2,2,2,2,0,0,0,0]
-        expected_phi_voxels = [2,2,2,2,0,0,0,0]
+        expected_theta_voxels = [4,4,4,4,5,5,5,5]
+        expected_phi_voxels = [2,2,2,2,3,3,3,3]
         self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_direction_travels_along_Y_axis(self):
+        ray_origin = np.array([0.0, -15.0, 0.0])
+        ray_direction = np.array([0.0, 1.0, 0.0])
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([30.0, 30.0, 30.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 8
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+
+        voxels = CythonSVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                 num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                 sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1,2,3,4,4,3,2,1]
+        expected_theta_voxels = [6,6,6,6,7,7,7,7]
+        expected_phi_voxels = [0,0,0,0,0,0,0,0]
+        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_direction_travels_along_Z_axis(self):
+        ray_origin = np.array([0.0, 0.0, -15.0])
+        ray_direction = np.array([0.0, 0.0, 1.0])
+        min_bound = np.array([0.0, 0.0, 0.0])
+        max_bound = np.array([30.0, 30.0, 30.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 8
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+
+        voxels = CythonSVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                 num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                 sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1,2,3,4,4,3,2,1]
+        expected_theta_voxels = [0,0,0,0,0,0,0,0]
+        expected_phi_voxels = [3,3,3,3,0,0,0,0]
+        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cpp/cython/CythonSVR_test.py
+++ b/cpp/cython/CythonSVR_test.py
@@ -123,6 +123,69 @@ class TestCythonizedSphericalVoxelTraversal(unittest.TestCase):
         expected_phi_voxels = [3,3,3,3,0,0,0,0]
         self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
 
+    def test_ray_parallel_to_XY_plane(self):
+        ray_origin = np.array([-15.0, -15.0, 0.0])
+        ray_direction = np.array([1.0, 1.0, 0.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 4
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+
+        voxels = CythonSVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                 num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                 sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1,2,3,4,4,3,2,1]
+        expected_theta_voxels = [2,2,2,2,0,0,0,0]
+        expected_phi_voxels = [2,2,2,2,3,3,3,3]
+        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_parallel_to_XZ_plane(self):
+        ray_origin = np.array([-15.0, 0.0, -15.0])
+        ray_direction = np.array([1.0, 0.0, 1.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 5
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+
+        voxels = CythonSVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                 num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                 sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1,2,3,4,5,5,4,3,2,1]
+        expected_theta_voxels = [2,2,2,2,2,3,3,3,3,3]
+        expected_phi_voxels = [2,2,2,2,2,0,0,0,0,0]
+        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
+    def test_ray_parallel_to_YZ_plane(self):
+        ray_origin = np.array([0.0, -15.0, -15.0])
+        ray_direction = np.array([0.0, 1.0, 1.0])
+        min_bound = np.array([-20.0, -20.0, -20.0])
+        max_bound = np.array([20.0, 20.0, 20.0])
+        sphere_center = np.array([0.0, 0.0, 0.0])
+        sphere_max_radius = 10.0
+        num_radial_sections = 5
+        num_angular_sections = 4
+        num_azimuthal_sections = 4
+        t_begin = 0.0
+        t_end = 30.0
+
+        voxels = CythonSVR.walk_spherical_volume(ray_origin, ray_direction, min_bound, max_bound, num_radial_sections,
+                                                 num_angular_sections, num_azimuthal_sections, sphere_center,
+                                                 sphere_max_radius, t_begin, t_end)
+        expected_radial_voxels = [1,2,3,4,5,5,4,3,2,1]
+        expected_theta_voxels = [3,3,3,3,3,0,0,0,0,0]
+        expected_phi_voxels = [3,3,3,3,3,0,0,0,0,0]
+        self.verifyVoxels(voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -91,26 +91,26 @@ struct GenHitParameters {
 // Related reading:
 //        Donald. E. Knuth, 1998, Addison-Wesley Longman, Inc., ISBN 0-201-89684-2, Addison-Wesley Professional;
 //        3rd edition. (The relevant equations are in §4.2.2, Eq. 36 and 37.)
-inline bool isKnEqual(double a, double b, double absEpsilon=ABS_EPSILON, double relEpsilon=REL_EPSILON) noexcept {
+inline bool isKnEqual(double a, double b) noexcept {
     const double diff = std::abs(a - b);
-    if (diff <= absEpsilon) { return true; }
-    return diff <= std::max(std::abs(a), std::abs(b)) * relEpsilon;
+    if (diff <= ABS_EPSILON) { return true; }
+    return diff <= std::max(std::abs(a), std::abs(b)) * REL_EPSILON;
 }
 
 // Overloaded version that checks for Knuth equality with vector cartesian coordinates.
-inline bool isKnEqual(const Vec3& a, const Vec3& b, double absEpsilon=ABS_EPSILON, double relEpsilon=REL_EPSILON) noexcept {
+inline bool isKnEqual(const Vec3& a, const Vec3& b) noexcept {
     const double diff_x = std::abs(a.x() - b.x());
     const double diff_y = std::abs(a.y() - b.y());
     const double diff_z = std::abs(a.z() - b.z());
-    if (diff_x <= absEpsilon && diff_y <= absEpsilon && diff_z <= absEpsilon) { return true; }
-    return diff_x <= std::max(std::abs(a.x()), std::abs(b.x())) * relEpsilon &&
-           diff_y <= std::max(std::abs(a.y()), std::abs(b.y())) * relEpsilon &&
-           diff_z <= std::max(std::abs(a.z()), std::abs(b.z())) * relEpsilon;
+    if (diff_x <= ABS_EPSILON && diff_y <= ABS_EPSILON && diff_z <= ABS_EPSILON) { return true; }
+    return diff_x <= std::max(std::abs(a.x()), std::abs(b.x())) * REL_EPSILON &&
+           diff_y <= std::max(std::abs(a.y()), std::abs(b.y())) * REL_EPSILON &&
+           diff_z <= std::max(std::abs(a.z()), std::abs(b.z())) * REL_EPSILON;
 }
 
 // Uses the Knuth algorithm in KnEqual() to ensure that a is strictly less than b.
-inline bool strictlyLessThan(double a, double b, double absEpsilon=ABS_EPSILON, double relEpsilon=REL_EPSILON) noexcept {
-    return a < b && !isKnEqual(a, b, absEpsilon, relEpsilon);
+inline bool strictlyLessThan(double a, double b) noexcept {
+    return a < b && !isKnEqual(a, b);
 }
 
 // Determines whether a radial hit occurs for the given ray. A radial hit is considered an intersection with

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -5,10 +5,10 @@
 #include <limits>
 
 #define DEBUG_STRINGS
-#define INITIALIZATION_DEBUG
+// #define INITIALIZATION_DEBUG
 #define TRAVERSAL_DEBUG
-#define ANGULAR_HIT_DEBUG
-#define AZIMUTHAL_HIT_DEBUG
+// #define ANGULAR_HIT_DEBUG
+// #define AZIMUTHAL_HIT_DEBUG
 
 // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
 enum VoxelIntersectionType {
@@ -24,7 +24,8 @@ enum VoxelIntersectionType {
 
 #ifdef DEBUG_STRINGS
     #include <string>
-    const char* ENUM_NAMES[] = {"None","Radial",  "Angular",  "Azimuthal", "RadialAngular", "RadialAzimuthal", "AngularAzimuthal", "RadialAngularAzimuthal"};
+    const char* ENUM_NAMES[] = {"None", "Radial", "Angular", "Azimuthal", "RadialAngular",
+                                "RadialAzimuthal", "AngularAzimuthal", "RadialAngularAzimuthal"};
     static std::vector<std::string> VoxelIntersectionTypeToString(ENUM_NAMES, std::end(ENUM_NAMES));
     const char* T_OR_F[] = {"False", "True"};
     static std::vector<std::string> BooleanValue(T_OR_F, std::end(T_OR_F));

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -425,8 +425,8 @@ inline VoxelIntersectionType minimumIntersection(const RadialHitParameters& rad_
 // Each time the radius changes, we need to update the angular and azimuthal voxel boundary segments.
 // This function updates Px_angular, Py_angular, Px_azimuthal, and Pz_azimuthal.
 inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::vector<double>& Py_angular,
-                                std::vector<double>& Px_azimuthal, std::vector<double>& Pz_azimuthal,
-                                const SphericalVoxelGrid& grid, std::size_t current_voxel_ID_r) noexcept {
+                                        std::vector<double>& Px_azimuthal, std::vector<double>& Pz_azimuthal,
+                                        const SphericalVoxelGrid& grid, std::size_t current_voxel_ID_r) noexcept {
     const double new_r = grid.sphereMaxRadius() - grid.deltaRadius() * (current_voxel_ID_r - 1);
     for (std::size_t l = 0; l < Px_angular.size(); ++l) {
         const double new_angular_x = grid.sphereCenter().x() - Px_angular[l];

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -421,19 +421,19 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
     for (std::size_t l = 0; l < Px_angular.size(); ++l) {
         const double new_angular_x = grid.sphereCenter().x() - Px_angular[l];
         const double new_angular_y = grid.sphereCenter().y() - Py_angular[l];
-        const double new_r_over_length = new_r / std::sqrt(new_angular_x * new_angular_x +
+        const double new_r_over_plane_length = new_r / std::sqrt(new_angular_x * new_angular_x +
                                                            new_angular_y * new_angular_y);
-        Px_angular[l] = grid.sphereCenter().x() - new_r_over_length * (grid.sphereCenter().x() - Px_angular[l]);
-        Py_angular[l] = grid.sphereCenter().y() - new_r_over_length * (grid.sphereCenter().y() - Py_angular[l]);
+        Px_angular[l] = grid.sphereCenter().x() - new_r_over_plane_length * (grid.sphereCenter().x() - Px_angular[l]);
+        Py_angular[l] = grid.sphereCenter().y() - new_r_over_plane_length * (grid.sphereCenter().y() - Py_angular[l]);
     }
     for (std::size_t m = 0; m < Px_azimuthal.size(); ++m) {
         const double new_azimuthal_x = grid.sphereCenter().x() - Px_azimuthal[m];
         const double new_azimuthal_z = grid.sphereCenter().z() - Pz_azimuthal[m];
-        const double new_r_over_length = new_r / std::sqrt(new_azimuthal_x * new_azimuthal_x +
+        const double new_r_over_plane_length = new_r / std::sqrt(new_azimuthal_x * new_azimuthal_x +
                                                            new_azimuthal_z * new_azimuthal_z);
-        Px_azimuthal[m] = grid.sphereCenter().x() - new_r_over_length *
+        Px_azimuthal[m] = grid.sphereCenter().x() - new_r_over_plane_length *
                                                     (grid.sphereCenter().x() - Px_azimuthal[m]);
-        Pz_azimuthal[m] = grid.sphereCenter().z() - new_r_over_length *
+        Pz_azimuthal[m] = grid.sphereCenter().z() - new_r_over_plane_length *
                                                     (grid.sphereCenter().z() - Pz_azimuthal[m]);
     }
 }
@@ -520,13 +520,13 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
         c = grid.sphereCenter().z() - ray.origin().z();
     }
 
-    const double ang_length = std::sqrt(a * a + b * b);
+    const double ang_plane_length = std::sqrt(a * a + b * b);
     BoundVec3 p_ang(0.0, 0.0, 0.0);
-    if (isKnEqual(ang_length, 0.0)) {
+    if (isKnEqual(ang_plane_length, 0.0)) {
         p_ang.x() = grid.sphereCenter().x() + current_r;
         p_ang.y() = grid.sphereCenter().y();
     } else {
-        p_ang = grid.sphereCenter() - FreeVec3(a, b, c) * (current_r / ang_length);
+        p_ang = grid.sphereCenter() - FreeVec3(a, b, c) * (current_r / ang_plane_length);
     }
 
     // p1 will lie between two angular voxel boundaries iff the angle between it and the angular boundary intersection
@@ -549,13 +549,13 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
         }
         ++i;
     }
-    const double azi_length = std::sqrt(a * a + c * c);
+    const double azi_plane_length = std::sqrt(a * a + c * c);
     BoundVec3 p_azi(0.0, 0.0, 0.0);
-    if (isKnEqual(azi_length, 0.0)) {
+    if (isKnEqual(azi_plane_length, 0.0)) {
         p_azi.x() = grid.sphereCenter().x() + current_r;
         p_azi.z() = grid.sphereCenter().z();
     } else {
-        p_azi = grid.sphereCenter() - FreeVec3(a, b, c) * (current_r / azi_length);
+        p_azi = grid.sphereCenter() - FreeVec3(a, b, c) * (current_r / azi_plane_length);
     }
 
     i = 0;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -176,7 +176,6 @@ RadialHitParameters radialHit(const Ray& ray, const SphericalVoxelGrid& grid, in
     } else if (times_gt_t.empty()) {
         // No intersection.
         radial_params.tMaxR = std::numeric_limits<double>::infinity();
-        radial_params.within_bounds = false;
         radial_params.tStepR = 0;
         radial_params.previous_transition_flag = false;
     } else {
@@ -208,7 +207,7 @@ RadialHitParameters radialHit(const Ray& ray, const SphericalVoxelGrid& grid, in
 }
 
 // A generalized version of the latter half of the angular and azimuthal hit parameters. Since the only difference
-// is the 2-d plane that they exist in, this portion can be generalized to a single function. The calculations
+// is the 2-d plane for which they exist in, this portion can be generalized to a single function call. The calculations
 // presented below follow closely the works of [Foley et al, 1996], [O'Rourke, 1998].
 // Quick reference: http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
 GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double perp_uv_max, double perp_uw_min,
@@ -432,7 +431,7 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
         const double new_angular_x = grid.sphereCenter().x() - Px_angular[l];
         const double new_angular_y = grid.sphereCenter().y() - Py_angular[l];
         const double new_r_over_plane_length = new_r / std::sqrt(new_angular_x * new_angular_x +
-                                                           new_angular_y * new_angular_y);
+                                                                 new_angular_y * new_angular_y);
         Px_angular[l] = grid.sphereCenter().x() - new_r_over_plane_length * (grid.sphereCenter().x() - Px_angular[l]);
         Py_angular[l] = grid.sphereCenter().y() - new_r_over_plane_length * (grid.sphereCenter().y() - Py_angular[l]);
     }
@@ -440,7 +439,8 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
         const double new_azimuthal_x = grid.sphereCenter().x() - Px_azimuthal[m];
         const double new_azimuthal_z = grid.sphereCenter().z() - Pz_azimuthal[m];
         const double new_r_over_plane_length = new_r / std::sqrt(new_azimuthal_x * new_azimuthal_x +
-                                                           new_azimuthal_z * new_azimuthal_z);
+
+                                                                 new_azimuthal_z * new_azimuthal_z);
         Px_azimuthal[m] = grid.sphereCenter().x() - new_r_over_plane_length *
                                                     (grid.sphereCenter().x() - Px_azimuthal[m]);
         Pz_azimuthal[m] = grid.sphereCenter().z() - new_r_over_plane_length *

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -4,12 +4,12 @@
 #include <cmath>
 #include <limits>
 
-#define DEBUG_STRINGS
-#define INITIALIZATION_DEBUG
+//#define DEBUG_STRINGS
+//#define INITIALIZATION_DEBUG
 //#define TRAVERSAL_DEBUG
 //#define RADIAL_HIT_DEBUG
 //#define ANGULAR_HIT_DEBUG
-#define AZIMUTHAL_HIT_DEBUG
+//#define AZIMUTHAL_HIT_DEBUG
 
 // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
 enum VoxelIntersectionType {
@@ -282,7 +282,7 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
         const double inv_perp_uv_min = 1.0 / perp_uv_min;
         a = perp_vw_min * inv_perp_uv_min;
         b = perp_uw_min * inv_perp_uv_min;
-        if ((a < 0.0 || a > 1.0) || (b < 0.0 || b > 1.0)) {
+        if ((strictlyLessThan(a, 0.0) || strictlyLessThan(1.0, a)) || strictlyLessThan(b, 0.0) || strictlyLessThan(1.0, b)) {
             is_intersect_min = false;
         } else {
             is_intersect_min = true;
@@ -297,7 +297,7 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
         const double inv_perp_uv_max = 1.0 / perp_uv_max;
         a = perp_vw_max * inv_perp_uv_max;
         b = perp_uw_max * inv_perp_uv_max;
-        if ((a < 0.0 || a > 1.0) || (b < 0.0 || b > 1.0)) {
+        if ((strictlyLessThan(a, 0.0) || strictlyLessThan(1.0, a)) || strictlyLessThan(b, 0.0) || strictlyLessThan(1.0, b)) {
             is_intersect_max = false;
         } else {
             is_intersect_max = true;
@@ -453,6 +453,7 @@ AzimuthalHitParameters azimuthalHit(const Ray& ray, const SphericalVoxelGrid& gr
 #ifdef AZIMUTHAL_HIT_DEBUG
     printf("\nAzimuthal Hit DEBUG:"
            "\nv: {%f, %f, %f}"
+           "\nu_max: {.x(): %f, .z(): %f}"
            "\npx_azimuthal: {%f, %f}"
            "\npz_azimuthal: {%f, %f}"
            "\nperp_uv_min: %f"
@@ -461,7 +462,7 @@ AzimuthalHitParameters azimuthalHit(const Ray& ray, const SphericalVoxelGrid& gr
            "\nperp_uw_max: %f"
            "\nperp_vw_min: %f"
            "\nperp_vw_max: %f",
-           v.x(), v.y(), v.z(), px_azimuthal_one, px_azimuthal_two,
+           v.x(), v.y(), v.z(), u_max.x(), u_max.z(), px_azimuthal_one, px_azimuthal_two,
            pz_azimuthal_one, pz_azimuthal_two, perp_uv_min,
            perp_uv_max, perp_uw_min, perp_uw_max,
            perp_vw_min, perp_vw_max);
@@ -537,8 +538,7 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
         const double new_angular_x = grid.sphereCenter().x() - Px_angular[l];
         const double new_angular_y = grid.sphereCenter().y() - Py_angular[l];
         const double new_r_over_length = new_r / std::sqrt(new_angular_x * new_angular_x +
-                                                           new_angular_y * new_angular_y +
-                                                           grid.sphereCenter().z() * grid.sphereCenter().z());
+                                                           new_angular_y * new_angular_y);
         Px_angular[l] = grid.sphereCenter().x() - new_r_over_length * (grid.sphereCenter().x() - Px_angular[l]);
         Py_angular[l] = grid.sphereCenter().y() - new_r_over_length * (grid.sphereCenter().y() - Py_angular[l]);
 #ifdef TRAVERSAL_DEBUG
@@ -550,7 +550,6 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
         const double new_azimuthal_x = grid.sphereCenter().x() - Px_azimuthal[m];
         const double new_azimuthal_z = grid.sphereCenter().z() - Pz_azimuthal[m];
         const double new_r_over_length = new_r / std::sqrt(new_azimuthal_x * new_azimuthal_x +
-                                                           grid.sphereCenter().y() * grid.sphereCenter().y() +
                                                            new_azimuthal_z * new_azimuthal_z);
         Px_azimuthal[m] = grid.sphereCenter().x() - new_r_over_length *
                                                     (grid.sphereCenter().x() - Px_azimuthal[m]);
@@ -847,7 +846,7 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
             case None: { return voxels; }
         }
         if (radius_has_stepped) {
-            // updateVoxelBoundarySegments(Px_angular, Py_angular, Px_azimuthal, Pz_azimuthal, grid, current_voxel_ID_r);
+            updateVoxelBoundarySegments(Px_angular, Py_angular, Px_azimuthal, Pz_azimuthal, grid, current_voxel_ID_r);
             radius_has_stepped = false;
         }
 #ifdef TRAVERSAL_DEBUG

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -604,7 +604,7 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
 #ifdef INITIALIZATION_DEBUG
     printf("\n----------------------------------"
            "\nInitialization Phase:"
-           "\nInitial Radial Voxel: %zu", current_voxel_ID_r);
+           "\nInitial Radial Voxel: %d", current_voxel_ID_r);
 #endif
 
     // Create an array of values representing the points of intersection between the lines corresponding
@@ -872,7 +872,7 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
         printf("\n--Voxel Pushed: {phi=%d}", current_voxel_ID_phi);
         printf("\n--Phi Voxel List: {");
         for (const auto voxel: voxels) {
-            printf(" %d", voxel.angular_voxel);
+            printf(" %d", voxel.azimuthal_voxel);
         }
         printf(" }\n");
 #endif

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -4,6 +4,10 @@
 #include <cmath>
 #include <limits>
 
+// Epsilons used for floating point comparisons in Knuth's algorithm.
+#define ABS_EPSILON 1e-12
+#define REL_EPSILON 1e-8
+
 //#define DEBUG_STRINGS
 //#define INITIALIZATION_DEBUG
 //#define TRAVERSAL_DEBUG
@@ -87,14 +91,14 @@ struct GenHitParameters {
 // Related reading:
 //        Donald. E. Knuth, 1998, Addison-Wesley Longman, Inc., ISBN 0-201-89684-2, Addison-Wesley Professional;
 //        3rd edition. (The relevant equations are in §4.2.2, Eq. 36 and 37.)
-inline bool isKnEqual(double a, double b, double absEpsilon=1e-12, double relEpsilon=1e-8) noexcept {
+inline bool isKnEqual(double a, double b, double absEpsilon=ABS_EPSILON, double relEpsilon=REL_EPSILON) noexcept {
     const double diff = std::abs(a - b);
     if (diff <= absEpsilon) { return true; }
     return diff <= std::max(std::abs(a), std::abs(b)) * relEpsilon;
 }
 
 // Overloaded version that checks for Knuth equality with vector cartesian coordinates.
-inline bool isKnEqual(const Vec3& a, const Vec3& b, double absEpsilon=1e-12, double relEpsilon=1e-8) noexcept {
+inline bool isKnEqual(const Vec3& a, const Vec3& b, double absEpsilon=ABS_EPSILON, double relEpsilon=REL_EPSILON) noexcept {
     const double diff_x = std::abs(a.x() - b.x());
     const double diff_y = std::abs(a.y() - b.y());
     const double diff_z = std::abs(a.z() - b.z());
@@ -105,7 +109,7 @@ inline bool isKnEqual(const Vec3& a, const Vec3& b, double absEpsilon=1e-12, dou
 }
 
 // Uses the Knuth algorithm in KnEqual() to ensure that a is strictly less than b.
-inline bool strictlyLessThan(double a, double b, double absEpsilon=1e-12, double relEpsilon=1e-8) noexcept {
+inline bool strictlyLessThan(double a, double b, double absEpsilon=ABS_EPSILON, double relEpsilon=REL_EPSILON) noexcept {
     return a < b && !isKnEqual(a, b, absEpsilon, relEpsilon);
 }
 
@@ -282,7 +286,8 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
         const double inv_perp_uv_min = 1.0 / perp_uv_min;
         a = perp_vw_min * inv_perp_uv_min;
         b = perp_uw_min * inv_perp_uv_min;
-        if ((strictlyLessThan(a, 0.0) || strictlyLessThan(1.0, a)) || strictlyLessThan(b, 0.0) || strictlyLessThan(1.0, b)) {
+        if ((strictlyLessThan(a, 0.0) || strictlyLessThan(1.0, a)) ||
+             strictlyLessThan(b, 0.0) || strictlyLessThan(1.0, b)) {
             is_intersect_min = false;
         } else {
             is_intersect_min = true;
@@ -297,7 +302,8 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
         const double inv_perp_uv_max = 1.0 / perp_uv_max;
         a = perp_vw_max * inv_perp_uv_max;
         b = perp_uw_max * inv_perp_uv_max;
-        if ((strictlyLessThan(a, 0.0) || strictlyLessThan(1.0, a)) || strictlyLessThan(b, 0.0) || strictlyLessThan(1.0, b)) {
+        if ((strictlyLessThan(a, 0.0) || strictlyLessThan(1.0, a)) ||
+             strictlyLessThan(b, 0.0) || strictlyLessThan(1.0, b)) {
             is_intersect_max = false;
         } else {
             is_intersect_max = true;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -242,7 +242,7 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
     GenHitParameters params;
     if (is_intersect_max && !is_intersect_min && t < t_max && t_max < t_end && !isKnEqual(t, t_max)) {
         params.tStep = 1;
-        params.tMax= t_max;
+        params.tMax = t_max;
         params.within_bounds = true;
         return params;
     }

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -600,7 +600,7 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
     bool radius_has_stepped = false;
     t_end = std::min(t_grid_exit, t_end);
 
-    while (true) {
+    while (t < t_end) {
         const auto radial_params = radialHit(ray, grid, current_voxel_ID_r, ray_sphere_vector_dot, t,
                                              t_end, v, previous_transition_flag);
         previous_transition_flag = radial_params.previous_transition_flag;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -4,17 +4,31 @@
 #include <cmath>
 #include <limits>
 
+#define DEBUG_STRINGS
+#define INITIALIZATION_DEBUG
+#define TRAVERSAL_DEBUG
+#define ANGULAR_HIT_DEBUG
+#define AZIMUTHAL_HIT_DEBUG
+
 // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
 enum VoxelIntersectionType {
-    None = -1,
-    Radial = 0,
-    Angular = 1,
-    Azimuthal = 2,
-    RadialAngular = 3,
-    RadialAzimuthal = 4,
-    AngularAzimuthal = 5,
-    RadialAngularAzimuthal = 6
+    None = 0,
+    Radial = 1,
+    Angular = 2,
+    Azimuthal = 3,
+    RadialAngular = 4,
+    RadialAzimuthal = 5,
+    AngularAzimuthal = 6,
+    RadialAngularAzimuthal = 7
 };
+
+#ifdef DEBUG_STRINGS
+    #include <string>
+    const char* ENUM_NAMES[] = {"None","Radial",  "Angular",  "Azimuthal", "RadialAngular", "RadialAzimuthal", "AngularAzimuthal", "RadialAngularAzimuthal"};
+    static std::vector<std::string> VoxelIntersectionTypeToString(ENUM_NAMES, std::end(ENUM_NAMES));
+    const char* T_OR_F[] = {"False", "True"};
+    static std::vector<std::string> BooleanValue(T_OR_F, std::end(T_OR_F));
+#endif
 
 // The parameters returned by radialHit().
 struct RadialHitParameters {
@@ -207,6 +221,20 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
                                      double num_voxels) noexcept {
     const bool is_parallel_min = isKnEqual(perp_uv_min, 0.0);
     const bool is_parallel_max = isKnEqual(perp_uv_max, 0.0);
+#ifdef ANGULAR_HIT_DEBUG
+    printf("\nAngular Hit DEBUG:"
+           "\nis_parallel_min: %s"
+           "\nis_parallel_max: %s",
+           BooleanValue[is_parallel_min].data(),
+           BooleanValue[is_parallel_max].data());
+#endif
+#ifdef AZIMUTHAL_HIT_DEBUG
+    printf("\nAzimuthal Hit DEBUG:"
+           "\nis_parallel_min: %s"
+           "\nis_parallel_max: %s",
+           BooleanValue[is_parallel_min].data(),
+           BooleanValue[is_parallel_max].data());
+#endif
     double a, b;
     bool is_intersect_min, is_intersect_max;
     double t_min = 0.0;
@@ -239,6 +267,20 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
     } else {
         is_intersect_max = false;
     }
+#ifdef ANGULAR_HIT_DEBUG
+    printf("\nAngular Hit DEBUG:"
+           "\nis_intersect_min: %s"
+           "\nis_intersect_max: %s",
+           BooleanValue[is_intersect_min].data(),
+           BooleanValue[is_intersect_max].data());
+#endif
+#ifdef AZIMUTHAL_HIT_DEBUG
+    printf("\nAzimuthal Hit DEBUG:"
+           "\nis_intersect_min: %s"
+           "\nis_intersect_max: %s",
+           BooleanValue[is_intersect_min].data(),
+           BooleanValue[is_intersect_max].data());
+#endif
     GenHitParameters params;
     if (is_intersect_max && !is_intersect_min && t < t_max && t_max < t_end && !isKnEqual(t, t_max)) {
         params.tStep = 1;
@@ -314,6 +356,17 @@ AngularHitParameters angularHit(const Ray& ray, const SphericalVoxelGrid& grid, 
     const double perp_uw_max = u_max.x() * w_max.y() - u_max.y() * w_max.x();
     const double perp_vw_min = v.x() * w_min.y() - v.y() * w_min.x();
     const double perp_vw_max = v.x() * w_max.y() - v.y() * w_max.x();
+#ifdef ANGULAR_HIT_DEBUG
+    printf("\nAngular Hit DEBUG:"
+           "\nperp_uv_min: %f"
+           "\nperp_uv_max: %f"
+           "\nperp_uw_min: %f"
+           "\nperp_uw_max: %f"
+           "\nperp_vw_min: %f"
+           "\nperp_vw_max: %f",
+           perp_uv_min, perp_uv_max, perp_uw_min,
+           perp_uw_max, perp_vw_min, perp_vw_max);
+#endif
     const GenHitParameters params = generalizedPlaneHit(ray, perp_uv_min, perp_uv_max, perp_uw_min, perp_uw_max,
                                                         perp_vw_min, perp_vw_max, p, v, t, t_end, ray.direction().y(),
                                                         grid.numAngularVoxels());
@@ -352,6 +405,17 @@ AzimuthalHitParameters azimuthalHit(const Ray& ray, const SphericalVoxelGrid& gr
     const double perp_uw_max = u_max.x() * w_max.z() - u_max.z() * w_max.x();
     const double perp_vw_min = v.x() * w_min.z() - v.z() * w_min.x();
     const double perp_vw_max = v.x() * w_max.z() - v.z() * w_max.x();
+#ifdef AZIMUTHAL_HIT_DEBUG
+    printf("\nAzimuthal Hit DEBUG:"
+           "\nperp_uv_min: %f"
+           "\nperp_uv_max: %f"
+           "\nperp_uw_min: %f"
+           "\nperp_uw_max: %f"
+           "\nperp_vw_min: %f"
+           "\nperp_vw_max: %f",
+           perp_uv_min, perp_uv_max, perp_uw_min,
+           perp_uw_max, perp_vw_min, perp_vw_max);
+#endif
     const GenHitParameters params = generalizedPlaneHit(ray, perp_uv_min, perp_uv_max, perp_uw_min, perp_uw_max,
                                                         perp_vw_min, perp_vw_max, p, v, t, t_end, ray.direction().z(),
                                                         grid.numAzimuthalVoxels());
@@ -415,6 +479,9 @@ inline VoxelIntersectionType calculateMinimumIntersection(const RadialHitParamet
 inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::vector<double>& Py_angular,
                                 std::vector<double>& Px_azimuthal, std::vector<double>& Pz_azimuthal,
                                 const SphericalVoxelGrid& grid, std::size_t current_voxel_ID_r) noexcept {
+#ifdef TRAVERSAL_DEBUG
+    printf("\nRadial Voxel Has Stepped. Update Voxel Boundary Segments...");
+#endif
     const double new_r = grid.sphereMaxRadius() - grid.deltaRadius() * (current_voxel_ID_r - 1);
     for (std::size_t l = 0; l < Px_angular.size(); ++l) {
         const double new_angular_x = grid.sphereCenter().x() - Px_angular[l];
@@ -424,6 +491,10 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
                                                            grid.sphereCenter().z() * grid.sphereCenter().z());
         Px_angular[l] = grid.sphereCenter().x() - new_r_over_length * (grid.sphereCenter().x() - Px_angular[l]);
         Py_angular[l] = grid.sphereCenter().y() - new_r_over_length * (grid.sphereCenter().y() - Py_angular[l]);
+#ifdef TRAVERSAL_DEBUG
+        printf("\nPx_angular[%zu]: %f\nPy_angular[%zu]: %f",
+               l, Px_angular[l], l, Py_angular[l]);
+#endif
     }
     for (std::size_t m = 0; m < Px_azimuthal.size(); ++m) {
         const double new_azimuthal_x = grid.sphereCenter().x() - Px_azimuthal[m];
@@ -435,6 +506,10 @@ inline void updateVoxelBoundarySegments(std::vector<double>& Px_angular, std::ve
                                                     (grid.sphereCenter().x() - Px_azimuthal[m]);
         Pz_azimuthal[m] = grid.sphereCenter().z() - new_r_over_length *
                                                     (grid.sphereCenter().z() - Pz_azimuthal[m]);
+#ifdef TRAVERSAL_DEBUG
+        printf("\nPx_azimuthal[%zu]: %f\nPz_azimuthal[%zu]: %f",
+               m, Px_azimuthal[m], m, Pz_azimuthal[m]);
+#endif
     }
 }
 
@@ -476,6 +551,12 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
     }
     std::size_t current_voxel_ID_r = 1 + (grid.sphereMaxRadius() - current_r) * grid.invDeltaRadius();
 
+#ifdef INITIALIZATION_DEBUG
+    printf("\n----------------------------------"
+           "\nInitialization Phase:"
+           "\nInitial Radial Voxel: %zu", current_voxel_ID_r);
+#endif
+
     // Create an array of values representing the points of intersection between the lines corresponding
     // to angular voxel boundaries and the initial radial voxel of the ray in the XY plane. This is similar for
     // azimuthal voxel boundaries, but in the XZ plane instead.
@@ -483,10 +564,17 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
     std::vector<double> Py_angular(grid.numAngularVoxels() + 1);
     std::vector<double> Px_azimuthal(grid.numAzimuthalVoxels() + 1);
     std::vector<double> Pz_azimuthal(grid.numAzimuthalVoxels() + 1);
+#ifdef INITIALIZATION_DEBUG
+    printf("\nArrayPoints:");
+#endif
     double k = 0;
     for (std::size_t j = 0; j < Px_angular.size(); ++j) {
         Px_angular[j] = current_r * std::cos(k) + grid.sphereCenter().x();
         Py_angular[j] = current_r * std::sin(k) + grid.sphereCenter().y();
+#ifdef INITIALIZATION_DEBUG
+        printf("\nPx_angular[%zu]: %f\nPy_angular[%zu]: %f",
+                j, Px_angular[j], j, Py_angular[j]);
+#endif
         k += grid.deltaTheta();
     }
     k = 0;
@@ -494,6 +582,10 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
         Px_azimuthal[n] = current_r * std::cos(k) + grid.sphereCenter().x();
         Pz_azimuthal[n] = current_r * std::sin(k) + grid.sphereCenter().z();
         k += grid.deltaPhi();
+#ifdef INITIALIZATION_DEBUG
+        printf("\nPx_azimuthal[%zu]: %f\nPz_azimuthal[%zu]: %f",
+               n, Px_azimuthal[n], n, Pz_azimuthal[n]);
+#endif
     }
 
     std::size_t current_voxel_ID_theta;
@@ -543,6 +635,9 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
         ++i;
     }
 
+#ifdef INITIALIZATION_DEBUG
+    printf("\nInitial Angular Voxel: %zu", current_voxel_ID_theta);
+#endif
     i = 0;
     while (i < Px_azimuthal.size() - 1) {
         const double px_diff = Px_azimuthal[i] - Px_azimuthal[i+1];
@@ -560,6 +655,9 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
         }
         ++i;
     }
+#ifdef INITIALIZATION_DEBUG
+    printf("\nInitial Azimuthal Voxel: %zu", current_voxel_ID_theta);
+#endif
     voxels.push_back({.radial_voxel=current_voxel_ID_r,
                       .angular_voxel=current_voxel_ID_theta,
                       .azimuthal_voxel=current_voxel_ID_phi});
@@ -574,6 +672,13 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
     bool previous_transition_flag = false;
     bool radius_has_stepped = false;
     t_end = std::min(t_grid_exit, t_end);
+#ifdef TRAVERSAL_DEBUG
+    printf("\n----------------------------------"
+           "\nTraversal Phase:"
+           "\n Initial Voxel: {%zu, %zu, %zu}"
+           "\nt: %f"
+           "\nt_end: %f", current_voxel_ID_r, current_voxel_ID_theta, current_voxel_ID_phi,t, t_end);
+#endif
 
     while (t < t_end) {
         const auto radial_params = radialHit(ray, grid, current_voxel_ID_r, ray_sphere_vector_dot, t,
@@ -587,7 +692,35 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
                                                    Px_azimuthal[current_voxel_ID_phi+1],
                                                    Pz_azimuthal[current_voxel_ID_phi],
                                                    Pz_azimuthal[current_voxel_ID_phi+1], t, t_end);
+#ifdef TRAVERSAL_DEBUG
+    printf("\nRadial parameters:"
+           "\n     tMaxR: %f"
+           "\n     tStepR: %zu"
+           "\n     within_bounds: %s"
+           "\n     exits_voxel_bounds: %s"
+           "\n     previous_transition_flag: %s",
+           radial_params.tMaxR,
+           radial_params.tStepR,
+           BooleanValue[radial_params.within_bounds].data(),
+           BooleanValue[radial_params.exits_voxel_bounds].data(),
+           BooleanValue[radial_params.previous_transition_flag].data());
+    printf("\nAngular parameters:"
+           "\n     tMaxTheta: %f"
+           "\n     tStepTheta: %zu"
+           "\n     within_bounds: %s",
+           angular_params.tMaxTheta, angular_params.tStepTheta,
+           BooleanValue[angular_params.within_bounds].data());
+    printf("\nAzimuthal parameters:"
+           "\n     tMaxPhi: %f"
+           "\n     tStepPhi: %zu"
+           "\n     within_bounds: %s",
+           azimuthal_params.tMaxPhi, azimuthal_params.tStepPhi,
+           BooleanValue[azimuthal_params.within_bounds].data());
+#endif
         const auto voxel_intersection = calculateMinimumIntersection(radial_params, angular_params, azimuthal_params);
+#ifdef TRAVERSAL_DEBUG
+        printf("\nVoxel Intersection: %s", VoxelIntersectionTypeToString[voxel_intersection].data());
+#endif
         switch(voxel_intersection) {
             case Radial: {
                 t = radial_params.tMaxR;
@@ -639,9 +772,31 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
             updateVoxelBoundarySegments(Px_angular, Py_angular, Px_azimuthal, Pz_azimuthal, grid, current_voxel_ID_r);
             radius_has_stepped = false;
         }
+#ifdef TRAVERSAL_DEBUG
+        printf("\nUpdated Time: %f", t);
+#endif
         voxels.push_back({.radial_voxel=current_voxel_ID_r,
                           .angular_voxel=current_voxel_ID_theta,
                           .azimuthal_voxel=current_voxel_ID_phi});
+#ifdef TRAVERSAL_DEBUG
+        printf("\nVoxel Pushed: {radial=%zu, theta=%zu, phi=%zu}", current_voxel_ID_r, current_voxel_ID_theta, current_voxel_ID_phi);
+#endif
+#ifdef ANGULAR_HIT_DEBUG
+        printf("\n--Voxel Pushed: {theta=%zu}", current_voxel_ID_theta);
+        printf("\n--Theta Voxel List: {");
+        for (const auto voxel: voxels) {
+            printf(" %zu", voxel.angular_voxel);
+        }
+        printf(" }\n");
+#endif
+#ifdef AZIMUTHAL_HIT_DEBUG
+        printf("\n--Voxel Pushed: {phi=%zu}", current_voxel_ID_phi);
+        printf("\n--Phi Voxel List: {");
+        for (const auto voxel: voxels) {
+            printf(" %zu", voxel.angular_voxel);
+        }
+        printf(" }\n");
+#endif
     }
     return voxels;
 }

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -5,8 +5,8 @@
 #include <limits>
 
 // Epsilons used for floating point comparisons in Knuth's algorithm.
-#define ABS_EPSILON 1e-12
-#define REL_EPSILON 1e-8
+const double ABS_EPSILON = 1e-12;
+const double REL_EPSILON = 1e-8;
 
 //#define DEBUG_STRINGS
 //#define INITIALIZATION_DEBUG

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -148,7 +148,7 @@ RadialHitParameters radialHit(const Ray& ray, const SphericalVoxelGrid& grid, in
     times_gt_t.erase(std::remove_if(times_gt_t.begin(), times_gt_t.end(), [t](double i) {
                                     return i < t || isKnEqual(i, t); }), times_gt_t.end());
     RadialHitParameters radial_params;
-    bool t_within_bounds;
+    bool t_within_bounds = false;
     if (times_gt_t.size() >= 2 && isKnEqual(intersection_times[0], intersection_times[1])) {
         // Ray is tangent to the circle, i.e. two intersection times are equal.
         radial_params.tMaxR = times_gt_t[0];
@@ -495,7 +495,8 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
         k += grid.deltaPhi();
     }
 
-    int current_voxel_ID_theta, current_voxel_ID_phi;
+    int current_voxel_ID_theta = -1;
+    int current_voxel_ID_phi = -1;
     double a, b, c;
     if (isKnEqual(ray.origin(), grid.sphereCenter())) {
         // If the ray starts at the sphere's center, we need to perturb slightly along

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -25,14 +25,18 @@ struct RadialHitParameters {
     // The time at which a hit occurs for the ray at the next point of intersection with a radial section.
     // This is always calculated from the ray origin.
     double tMaxR;
+
     // The voxel traversal value of a radial step: 0, +1, -1. This is added to the current radial voxel.
     int tStepR;
+
     // Determine whether the current voxel traversal was a 'transition'. This is necessary to determine when
     // The radial steps should go from negative to positive or vice-versa,
     // since the radial voxels go from 1..N, where N is the number of radial sections.
     bool previous_transition_flag;
+
     // Determines whether the current hit is within time bounds (t, t_end).
     bool within_bounds;
+
     // Determines whether the current voxel hit has caused a step outside of the spherical voxel grid.
     bool exits_voxel_bounds;
 };
@@ -42,8 +46,10 @@ struct AngularHitParameters {
     // The time at which a hit occurs for the ray at the next point of intersection with an angular section.
     // This is always calculated from the ray origin.
     double tMaxTheta;
+
     // The voxel traversal value of an angular step: 0, +1, -1. This is added to the current angular voxel.
     int tStepTheta;
+
     // Determines whether the current hit is within time bounds (t, t_end).
     bool within_bounds;
 };
@@ -53,8 +59,10 @@ struct AzimuthalHitParameters {
     // The time at which a hit occurs for the ray at the next point of intersection with an azimuthal section.
     // This is always calculated from the ray origin.
     double tMaxPhi;
+
     // The voxel traversal value of an azimuthal step: 0, +1, -1. This is added to the current azimuthal voxel.
     int tStepPhi;
+
     // Determines whether the current hit is within time bounds (t, t_end).
     bool within_bounds;
 };
@@ -300,7 +308,8 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
 //
 // Returns: the corresponding angular hit parameters.
 AngularHitParameters angularHit(const Ray& ray, const SphericalVoxelGrid& grid, double px_angular_one,
-        double px_angular_two, double py_angular_one, double py_angular_two, double t, double t_end) noexcept {
+                                double px_angular_two, double py_angular_one, double py_angular_two,
+                                double t, double t_end) noexcept {
     // Ray segment vector.
     const BoundVec3 p = ray.pointAtParameter(t);
     const BoundVec3 p_end = ray.pointAtParameter(t_end);
@@ -338,7 +347,8 @@ AngularHitParameters angularHit(const Ray& ray, const SphericalVoxelGrid& grid, 
 //
 // Returns: the corresponding azimuthal hit parameters.
 AzimuthalHitParameters azimuthalHit(const Ray& ray, const SphericalVoxelGrid& grid,  double px_azimuthal_one,
-        double px_azimuthal_two, double pz_azimuthal_one, double pz_azimuthal_two, double t, double t_end) noexcept {
+                                    double px_azimuthal_two, double pz_azimuthal_one, double pz_azimuthal_two,
+                                    double t, double t_end) noexcept {
     // Ray segment vector.
     const BoundVec3 p = ray.pointAtParameter(t);
     const BoundVec3 p_end = ray.pointAtParameter(t_end);
@@ -382,8 +392,8 @@ AzimuthalHitParameters azimuthalHit(const Ray& ray, const SphericalVoxelGrid& gr
 // (1) tMax must be within bounds
 // (2) Either tMax is a strict minimum OR the next step is a radial exit.
 inline VoxelIntersectionType minimumIntersection(const RadialHitParameters& rad_params,
-                                                          const AngularHitParameters& ang_params,
-                                                          const AzimuthalHitParameters& azi_params) noexcept {
+                                                 const AngularHitParameters& ang_params,
+                                                 const AzimuthalHitParameters& azi_params) noexcept {
     if (ang_params.within_bounds && ((ang_params.tMaxTheta < rad_params.tMaxR
                                       && rad_params.tMaxR < azi_params.tMaxPhi) || rad_params.exits_voxel_bounds)) {
         return VoxelIntersectionType::Angular;
@@ -602,8 +612,8 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
     t_end = std::min(t_grid_exit, t_end);
 
     while (t < t_end) {
-        const auto radial_params = radialHit(ray, grid, current_voxel_ID_r, ray_sphere_vector_dot, t,
-                                             t_end, v, previous_transition_flag);
+        const auto radial_params = radialHit(ray, grid, current_voxel_ID_r, ray_sphere_vector_dot,
+                                             t, t_end, v, previous_transition_flag);
         previous_transition_flag = radial_params.previous_transition_flag;
         const auto angular_params = angularHit(ray, grid, Px_angular[current_voxel_ID_theta],
                                                Px_angular[current_voxel_ID_theta+1],

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -28,8 +28,8 @@ struct RadialHitParameters {
     // The voxel traversal value of a radial step: 0, +1, -1. This is added to the current radial voxel.
     int tStepR;
     // Determine whether the current voxel traversal was a 'transition'. This is necessary to determine when
-    // The radial steps should go from negative to positive or vice-versa, since the radial voxels go from 1..N, where N
-    // is the number of radial sections.
+    // The radial steps should go from negative to positive or vice-versa,
+    // since the radial voxels go from 1..N, where N is the number of radial sections.
     bool previous_transition_flag;
     // Determines whether the current hit is within time bounds (t, t_end).
     bool within_bounds;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -316,7 +316,7 @@ AngularHitParameters angularHit(const Ray& ray, const SphericalVoxelGrid& grid, 
     const double perp_vw_max = v.x() * w_max.y() - v.y() * w_max.x();
     const GenHitParameters params = generalizedPlaneHit(ray, perp_uv_min, perp_uv_max, perp_uw_min, perp_uw_max,
                                                         perp_vw_min, perp_vw_max, p, v, t, t_end, ray.direction().y(),
-                                                        grid.numRadialVoxels());
+                                                        grid.numAngularVoxels());
     return {.tMaxTheta=params.tMax, .tStepTheta=params.tStep, .within_bounds=params.within_bounds};
 }
 

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -28,7 +28,7 @@ enum VoxelIntersectionType {
                                 "RadialAzimuthal", "AngularAzimuthal", "RadialAngularAzimuthal"};
     static std::vector<std::string> VoxelIntersectionTypeToString(ENUM_NAMES, std::end(ENUM_NAMES));
     const char* T_OR_F[] = {"False", "True"};
-    static std::vector<std::string> BooleanValue(T_OR_F, std::end(T_OR_F));
+    static std::vector<std::string> BooleanToString(T_OR_F, std::end(T_OR_F));
 #endif
 
 // The parameters returned by radialHit().
@@ -226,15 +226,15 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
     printf("\nAngular Hit DEBUG:"
            "\nis_parallel_min: %s"
            "\nis_parallel_max: %s",
-           BooleanValue[is_parallel_min].data(),
-           BooleanValue[is_parallel_max].data());
+           BooleanToString[is_parallel_min].data(),
+           BooleanToString[is_parallel_max].data());
 #endif
 #ifdef AZIMUTHAL_HIT_DEBUG
     printf("\nAzimuthal Hit DEBUG:"
            "\nis_parallel_min: %s"
            "\nis_parallel_max: %s",
-           BooleanValue[is_parallel_min].data(),
-           BooleanValue[is_parallel_max].data());
+           BooleanToString[is_parallel_min].data(),
+           BooleanToString[is_parallel_max].data());
 #endif
     double a, b;
     bool is_intersect_min, is_intersect_max;
@@ -272,15 +272,15 @@ GenHitParameters generalizedPlaneHit(const Ray& ray, double perp_uv_min, double 
     printf("\nAngular Hit DEBUG:"
            "\nis_intersect_min: %s"
            "\nis_intersect_max: %s",
-           BooleanValue[is_intersect_min].data(),
-           BooleanValue[is_intersect_max].data());
+           BooleanToString[is_intersect_min].data(),
+           BooleanToString[is_intersect_max].data());
 #endif
 #ifdef AZIMUTHAL_HIT_DEBUG
     printf("\nAzimuthal Hit DEBUG:"
            "\nis_intersect_min: %s"
            "\nis_intersect_max: %s",
-           BooleanValue[is_intersect_min].data(),
-           BooleanValue[is_intersect_max].data());
+           BooleanToString[is_intersect_min].data(),
+           BooleanToString[is_intersect_max].data());
 #endif
     GenHitParameters params;
     if (is_intersect_max && !is_intersect_min && t < t_max && t_max < t_end && !isKnEqual(t, t_max)) {
@@ -702,21 +702,21 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
            "\n     previous_transition_flag: %s",
            radial_params.tMaxR,
            radial_params.tStepR,
-           BooleanValue[radial_params.within_bounds].data(),
-           BooleanValue[radial_params.exits_voxel_bounds].data(),
-           BooleanValue[radial_params.previous_transition_flag].data());
+           BooleanToString[radial_params.within_bounds].data(),
+           BooleanToString[radial_params.exits_voxel_bounds].data(),
+           BooleanToString[radial_params.previous_transition_flag].data());
     printf("\nAngular parameters:"
            "\n     tMaxTheta: %f"
            "\n     tStepTheta: %zu"
            "\n     within_bounds: %s",
            angular_params.tMaxTheta, angular_params.tStepTheta,
-           BooleanValue[angular_params.within_bounds].data());
+           BooleanToString[angular_params.within_bounds].data());
     printf("\nAzimuthal parameters:"
            "\n     tMaxPhi: %f"
            "\n     tStepPhi: %zu"
            "\n     within_bounds: %s",
            azimuthal_params.tMaxPhi, azimuthal_params.tStepPhi,
-           BooleanValue[azimuthal_params.within_bounds].data());
+           BooleanToString[azimuthal_params.within_bounds].data());
 #endif
         const auto voxel_intersection = calculateMinimumIntersection(radial_params, angular_params, azimuthal_params);
 #ifdef TRAVERSAL_DEBUG
@@ -780,7 +780,8 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
                           .angular_voxel=current_voxel_ID_theta,
                           .azimuthal_voxel=current_voxel_ID_phi});
 #ifdef TRAVERSAL_DEBUG
-        printf("\nVoxel Pushed: {radial=%zu, theta=%zu, phi=%zu}", current_voxel_ID_r, current_voxel_ID_theta, current_voxel_ID_phi);
+        printf("\nVoxel Pushed: {radial=%zu, theta=%zu, phi=%zu}", current_voxel_ID_r,
+                current_voxel_ID_theta, current_voxel_ID_phi);
 #endif
 #ifdef ANGULAR_HIT_DEBUG
         printf("\n--Voxel Pushed: {theta=%zu}", current_voxel_ID_theta);

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -600,7 +600,7 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
     bool radius_has_stepped = false;
     t_end = std::min(t_grid_exit, t_end);
 
-    while (t < t_end) {
+    while (true) {
         const auto radial_params = radialHit(ray, grid, current_voxel_ID_r, ray_sphere_vector_dot, t,
                                              t_end, v, previous_transition_flag);
         previous_transition_flag = radial_params.previous_transition_flag;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -762,7 +762,7 @@ sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid
         const auto radial_params = radialHit(ray, grid, current_voxel_ID_r, ray_sphere_vector_dot, t,
                                              t_end, v, previous_transition_flag);
         previous_transition_flag = radial_params.previous_transition_flag;
-        const auto angular_params = angularHit(ray, grid, Px_angular[current_voxel_ID_thetagit ],
+        const auto angular_params = angularHit(ray, grid, Px_angular[current_voxel_ID_theta],
                                                Px_angular[current_voxel_ID_theta+1],
                                                Py_angular[current_voxel_ID_theta],
                                                Py_angular[current_voxel_ID_theta+1], t, t_end);

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -8,9 +8,9 @@
 
 // Represents a spherical voxel coordinate.
     struct SphericalVoxel {
-        std::size_t radial_voxel;
-        std::size_t angular_voxel;
-        std::size_t azimuthal_voxel;
+        int radial_voxel;
+        int angular_voxel;
+        int azimuthal_voxel;
     };
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the 'ray' over the spherical voxel grid

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -13,17 +13,10 @@ struct SphericalVoxel {
     int azimuthal_voxel;
 };
 
-// A spherical coordinate voxel traversal algorithm. The algorithm traces the 'ray' over the spherical voxel grid
-// provided. 't_begin' is the time the ray begins, and 't_end' is the time the ray ends.
-//
-// Requires:
-//    'ray' is a valid Ray.
-//    'grid' is a valid SphericalVoxelGrid.
-//    t_end > t_begin >= 0.0
-//
-// Returns:
-//    A vector of the spherical coordinate voxels traversed. Recall that if, for example, a radial hit occurs,
-//    The azimuthal and angular voxels will remain the same as before. This applies for each traversal.
+// A spherical coordinate voxel traversal algorithm. The algorithm traces the ray over the spherical voxel grid
+// provided. t_begin is the time the ray begins, and t_end is the time at which the ray ends. Returns a vector of the
+// spherical coordinate voxels traversed. Recall that if, for example, a radial hit occurs, The azimuthal and
+// angular voxels will remain the same as before. This applies for each traversal type.
 //
 // Notes: For further documentation and visualization, see the Progress Report for the algorithm:
 // https://docs.google.com/document/d/1ixD7XNu39kwwXhvQooMNb79x18-GsyMPLodzvwC3X-E/edit?usp=sharing

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -7,11 +7,11 @@
 #include <vector>
 
 // Represents a spherical voxel coordinate.
-    struct SphericalVoxel {
-        int radial_voxel;
-        int angular_voxel;
-        int azimuthal_voxel;
-    };
+struct SphericalVoxel {
+    int radial_voxel;
+    int angular_voxel;
+    int azimuthal_voxel;
+};
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the 'ray' over the spherical voxel grid
 // provided. 't_begin' is the time the ray begins, and 't_end' is the time the ray ends.
@@ -32,11 +32,11 @@ std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, co
 
 // Simplified parameters to Cythonize the function; implementation remains the same as above.
 std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double* ray_origin, double* ray_direction,
-                                                              double* min_bound, double* max_bound,
+                                                                double* min_bound, double* max_bound,
                                                                 std::size_t num_radial_voxels,
                                                                 std::size_t num_angular_voxels,
                                                                 std::size_t num_azimuthal_voxels, double* sphere_center,
-                                                              double sphere_max_radius, double t_begin,
-                                                              double t_end) noexcept;
+                                                                double sphere_max_radius, double t_begin,
+                                                                double t_end) noexcept;
 
 #endif //SPHERICAL_VOLUME_RENDERING_SPHERICALVOLUMERENDERINGUTIL_H

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -85,10 +85,10 @@ private:
     const double sphere_max_radius_;
 
     // The maximum sphere radius divided by the number of radial sections.
-    const double delta_radius_, inv_delta_radius_;
+    const double delta_radius_, delta_theta_, delta_phi_;
 
     // Sphere's area divided by the number of angular sections and number of azimuthal sections respectively.
-    const double delta_theta_, delta_phi_, inv_delta_theta_, inv_delta_phi_;
+    const double inv_delta_radius_, inv_delta_theta_, inv_delta_phi_;
 };
 
 #endif //SPHERICAL_VOLUME_RENDERING_SPHERICALVOXELGRID_H

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -85,9 +85,12 @@ private:
     const double sphere_max_radius_;
 
     // The maximum sphere radius divided by the number of radial sections.
-    const double delta_radius_, delta_theta_, delta_phi_;
+    const double delta_radius_;
 
-    // Sphere's area divided by the number of angular sections and number of azimuthal sections respectively.
+    // 2 * PI divided by X, where X is the number of angular and number of azimuthal sections respectively.
+    const double delta_theta_, delta_phi_;
+
+    // Inverse of the above delta values.
     const double inv_delta_radius_, inv_delta_theta_, inv_delta_phi_;
 };
 

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -16,22 +16,22 @@ public:
     SphericalVoxelGrid(const BoundVec3& min_bound, const BoundVec3& max_bound, std::size_t num_radial_voxels,
                        std::size_t num_angular_voxels, std::size_t num_azimuthal_voxels, const BoundVec3& sphere_center,
                        double sphere_max_radius) :
-            min_bound_(min_bound),
-            max_bound_(max_bound),
-            num_radial_voxels_(num_radial_voxels),
-            num_angular_voxels_(num_angular_voxels),
-            num_azimuthal_voxels_(num_azimuthal_voxels),
-            inv_num_radial_voxels_(1.0 / num_radial_voxels),
-            inv_num_angular_voxels_(1.0 / num_angular_voxels),
-            inv_num_azimuthal_voxels_(1.0 / num_azimuthal_voxels),
-            sphere_center_(sphere_center),
-            sphere_max_radius_(sphere_max_radius),
-            delta_radius_(sphere_max_radius * inv_num_radial_voxels_),
-            delta_theta_(2 * M_PI * inv_num_angular_voxels_),
-            delta_phi_(2 * M_PI * inv_num_azimuthal_voxels_),
-            inv_delta_radius_(1.0 / delta_radius_),
-            inv_delta_theta_(1.0 / delta_theta_),
-            inv_delta_phi_(1.0 / delta_phi_) {}
+                       min_bound_(min_bound),
+                       max_bound_(max_bound),
+                       num_radial_voxels_(num_radial_voxels),
+                       num_angular_voxels_(num_angular_voxels),
+                       num_azimuthal_voxels_(num_azimuthal_voxels),
+                       inv_num_radial_voxels_(1.0 / num_radial_voxels),
+                       inv_num_angular_voxels_(1.0 / num_angular_voxels),
+                       inv_num_azimuthal_voxels_(1.0 / num_azimuthal_voxels),
+                       sphere_center_(sphere_center),
+                       sphere_max_radius_(sphere_max_radius),
+                       delta_radius_(sphere_max_radius * inv_num_radial_voxels_),
+                       delta_theta_(2 * M_PI * inv_num_angular_voxels_),
+                       delta_phi_(2 * M_PI * inv_num_azimuthal_voxels_),
+                       inv_delta_radius_(1.0 / delta_radius_),
+                       inv_delta_theta_(1.0 / delta_theta_),
+                       inv_delta_phi_(1.0 / delta_phi_) {}
 
     inline std::size_t numRadialVoxels() const { return num_radial_voxels_; }
 

--- a/cpp/testing/spherical_volume_rendering_test.cpp
+++ b/cpp/testing/spherical_volume_rendering_test.cpp
@@ -24,7 +24,7 @@ namespace {
         std::vector<int> theta_voxels(num_voxels);
         std::vector<int> phi_voxels(num_voxels);
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), radial_voxels.begin(),
-                [](const SphericalVoxel& sv) -> int { return sv.radial_voxel; });
+                       [](const SphericalVoxel& sv) -> int { return sv.radial_voxel; });
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), theta_voxels.begin(),
                        [](const SphericalVoxel& sv) -> int { return sv.angular_voxel; });
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), phi_voxels.begin(),

--- a/cpp/testing/spherical_volume_rendering_test.cpp
+++ b/cpp/testing/spherical_volume_rendering_test.cpp
@@ -151,4 +151,78 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
+    TEST(SphericalCoordinateTraversal, RayParallelToXYPlane) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
+        const FreeVec3 ray_direction(1.0, 1.0, 0.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<std::size_t> expected_theta_voxels = {2,2,2,2,0,0,0,0};
+        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,3,3,3,3};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayParallelToXZPlane) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 5;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
+        const FreeVec3 ray_direction(1.0, 0.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,5,5,4,3,2,1};
+        const std::vector<std::size_t> expected_theta_voxels = {2,2,2,2,2,3,3,3,3,3};
+        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,2,0,0,0,0,0};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayParallelToYZPlane) {
+        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
+        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 5;
+        const std::size_t num_angular_sections = 4;
+        const std::size_t num_azimuthal_sections = 4;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(0.0, -15.0, -15.0);
+        const FreeVec3 ray_direction(0.0, 1.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,5,5,4,3,2,1};
+        const std::vector<std::size_t> expected_theta_voxels = {3,3,3,3,3,0,0,0,0,0};
+        const std::vector<std::size_t> expected_phi_voxels = {3,3,3,3,3,0,0,0,0,0};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+
+
 }

--- a/cpp/testing/spherical_volume_rendering_test.cpp
+++ b/cpp/testing/spherical_volume_rendering_test.cpp
@@ -79,51 +79,76 @@ namespace {
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
-    TEST(SphericalCoordinateTraversal, RayDirectionSlightlyOffsetInXYPlane) {
-        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
-        const BoundVec3 max_bound(20.0, 20.0, 20.0);
+    TEST(SphericalCoordinateTraversal, RayTravelsAlongXAxis) {
+        const BoundVec3 min_bound(0.0, 0.0, 0.0);
+        const BoundVec3 max_bound(30.0, 30.0, 30.0);
         const BoundVec3 sphere_center(0.0, 0.0, 0.0);
         const double sphere_max_radius = 10.0;
         const std::size_t num_radial_sections = 4;
-        const std::size_t num_angular_sections = 4;
+        const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
         const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
-        const FreeVec3 ray_direction(1.0, 1.5, 1.0);
-        const Ray ray(ray_origin, ray_direction);
-        const double t_begin = 0.0;
-        const double t_end = 30.0;
-
-        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,2,3,2,2,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {2,2,1,1,1,1,0,0};
-        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,2,0,0,0};
-        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
-    }
-
-    TEST(SphericalCoordinateTraversal, RayParallelToXYPlane) {
-        const BoundVec3 min_bound(-20.0, -20.0, -20.0);
-        const BoundVec3 max_bound(20.0, 20.0, 20.0);
-        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10.0;
-        const std::size_t num_radial_sections = 4;
-        const std::size_t num_angular_sections = 4;
-        const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                      num_angular_sections,
-                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
-        const FreeVec3 ray_direction(1.0, 1.0, 0.0);
+        const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
+        const FreeVec3 ray_direction(1.0, 0.0, 0.0);
         const Ray ray(ray_origin, ray_direction);
         const double t_begin = 0.0;
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
         const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {2,2,2,2,0,0,0,0};
-        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,0,0,0,0};
+        const std::vector<std::size_t> expected_theta_voxels = {4,4,4,4,5,5,5,5};
+        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,3,3,3,3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
+
+    TEST(SphericalCoordinateTraversal, RayTravelsAlongYAxis) {
+        const BoundVec3 min_bound(0.0, 0.0, 0.0);
+        const BoundVec3 max_bound(30.0, 30.0, 30.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 8;
+        const std::size_t num_azimuthal_sections = 4;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(0.0, -15.0, 0.0);
+        const FreeVec3 ray_direction(0.0, 1.0, 0.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<std::size_t> expected_theta_voxels = {6,6,6,6,7,7,7,7};
+        const std::vector<std::size_t> expected_phi_voxels = {0,0,0,0,0,0,0,0};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
+    TEST(SphericalCoordinateTraversal, RayTravelsAlongZAxis) {
+        const BoundVec3 min_bound(0.0, 0.0, 0.0);
+        const BoundVec3 max_bound(30.0, 30.0, 30.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10.0;
+        const std::size_t num_radial_sections = 4;
+        const std::size_t num_angular_sections = 8;
+        const std::size_t num_azimuthal_sections = 4;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const BoundVec3 ray_origin(0.0, 0.0, -15.0);
+        const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+        const Ray ray(ray_origin, ray_direction);
+        const double t_begin = 0.0;
+        const double t_end = 30.0;
+
+        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<std::size_t> expected_theta_voxels = {0,0,0,0,0,0,0,0};
+        const std::vector<std::size_t> expected_phi_voxels = {3,3,3,3,0,0,0,0};
+        expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
+    }
+
 }

--- a/cpp/testing/spherical_volume_rendering_test.cpp
+++ b/cpp/testing/spherical_volume_rendering_test.cpp
@@ -16,19 +16,19 @@
 namespace {
     // Determines equality amongst actual spherical voxels, and the expected spherical voxels.
     void expectEqualVoxels(const std::vector<SphericalVoxel>& actual_voxels,
-                           const std::vector<std::size_t>& expected_radial_voxels,
-                           const std::vector<std::size_t>& expected_theta_voxels,
-                           const std::vector<std::size_t>& expected_phi_voxels) {
+                           const std::vector<int>& expected_radial_voxels,
+                           const std::vector<int>& expected_theta_voxels,
+                           const std::vector<int>& expected_phi_voxels) {
         const std::size_t num_voxels = actual_voxels.size();
-        std::vector<std::size_t> radial_voxels(num_voxels);
-        std::vector<std::size_t> theta_voxels(num_voxels);
-        std::vector<std::size_t> phi_voxels(num_voxels);
+        std::vector<int> radial_voxels(num_voxels);
+        std::vector<int> theta_voxels(num_voxels);
+        std::vector<int> phi_voxels(num_voxels);
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), radial_voxels.begin(),
-                [](const SphericalVoxel& sv) -> std::size_t { return sv.radial_voxel; });
+                [](const SphericalVoxel& sv) -> int { return sv.radial_voxel; });
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), theta_voxels.begin(),
-                       [](const SphericalVoxel& sv) -> std::size_t { return sv.angular_voxel; });
+                       [](const SphericalVoxel& sv) -> int { return sv.angular_voxel; });
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), phi_voxels.begin(),
-                       [](const SphericalVoxel& sv) -> std::size_t { return sv.azimuthal_voxel; });
+                       [](const SphericalVoxel& sv) -> int { return sv.azimuthal_voxel; });
         EXPECT_THAT(radial_voxels, testing::ContainerEq(expected_radial_voxels));
         EXPECT_THAT(theta_voxels, testing::ContainerEq(expected_theta_voxels));
         EXPECT_THAT(phi_voxels, testing::ContainerEq(expected_phi_voxels));
@@ -73,9 +73,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {2,2,2,2,0,0,0,0};
-        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,0,0,0,0};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {2,2,2,2,0,0,0,0};
+        const std::vector<int> expected_phi_voxels = {2,2,2,2,0,0,0,0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -97,9 +97,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {4,4,4,4,5,5,5,5};
-        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,3,3,3,3};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {4,4,4,4,5,5,5,5};
+        const std::vector<int> expected_phi_voxels = {2,2,2,2,3,3,3,3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -121,9 +121,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {6,6,6,6,7,7,7,7};
-        const std::vector<std::size_t> expected_phi_voxels = {0,0,0,0,0,0,0,0};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {6,6,6,6,7,7,7,7};
+        const std::vector<int> expected_phi_voxels = {0,0,0,0,0,0,0,0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -145,9 +145,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {0,0,0,0,0,0,0,0};
-        const std::vector<std::size_t> expected_phi_voxels = {3,3,3,3,0,0,0,0};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {0,0,0,0,0,0,0,0};
+        const std::vector<int> expected_phi_voxels = {3,3,3,3,0,0,0,0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -169,9 +169,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {2,2,2,2,0,0,0,0};
-        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,3,3,3,3};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {2,2,2,2,0,0,0,0};
+        const std::vector<int> expected_phi_voxels = {2,2,2,2,3,3,3,3};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -193,9 +193,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,5,5,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {2,2,2,2,2,3,3,3,3,3};
-        const std::vector<std::size_t> expected_phi_voxels = {2,2,2,2,2,0,0,0,0,0};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,5,5,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {2,2,2,2,2,3,3,3,3,3};
+        const std::vector<int> expected_phi_voxels = {2,2,2,2,2,0,0,0,0,0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
 
@@ -217,12 +217,9 @@ namespace {
         const double t_end = 30.0;
 
         const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-        const std::vector<std::size_t> expected_radial_voxels = {1,2,3,4,5,5,4,3,2,1};
-        const std::vector<std::size_t> expected_theta_voxels = {3,3,3,3,3,0,0,0,0,0};
-        const std::vector<std::size_t> expected_phi_voxels = {3,3,3,3,3,0,0,0,0,0};
+        const std::vector<int> expected_radial_voxels = {1,2,3,4,5,5,4,3,2,1};
+        const std::vector<int> expected_theta_voxels = {3,3,3,3,3,0,0,0,0,0};
+        const std::vector<int> expected_phi_voxels = {3,3,3,3,3,0,0,0,0,0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
-
-
-
 }


### PR DESCRIPTION
The cpp version did not pass the basic spherical tests. This PR fixes this. All tests (both cpp and Cythonized) provided in the test files below pass. If  you haven't been tracking my recent changes, it may be easier to read the entire file without diffs.

### changes
- Change tStep to a signed type, since it can be negative.
- Add constants ABS_EPSILON, REL_EPSILON.
- Copied a few test cases from #89 with corrected voxels.
- Add function KnLessThan(), which ensures ```a *is strictly less than* b```.
- Instead of checking the conditionals 
```
t *strictly less than* tMax && tMax *strictly less than* t_end
``` 
in the while loop, I've added these to the corresponding functions radialHit(), angularHit(), azimuthalHit().
- Update generalizedPlaneHit() to use strictlyLessThan for comparisons with a, b.
- Update tests in Cythonized code.
- Rid code of C++11 compiler warnings.
- Code cleanup, other small changes such as starting enums from 0.

### bug fixes
- Fix bug in angularHit(): It used numRadialVoxels() instead of numAngularVoxels().
- Fix bug in radialHit(): From the MATLAB algorithm, I assumed that the vector ```time``` was always used; this is not the case. Both ```time``` and ```time_array``` are used in the statements that follow. I've re-named these to ```intersection_times``` and ```times_gt_t``` to be more clear about their roles.
- Correctly update voxel boundary segments to use length in the plane rather than 3-dimensional length.
