### PR TITLE
Add Chord length Test

### DIFF
--- a/matlab/spherical-traversal/sphericalCoordinateTraversal.m
+++ b/matlab/spherical-traversal/sphericalCoordinateTraversal.m
@@ -403,6 +403,9 @@ while t < t_end
     else
        return;
     end
+    if verbose:
+        fprintf('\nCurrently, we have spent %d time on traversal\n',acc)
+    end
     % If the radial voxel changes, update the angular voxel boundary
     % segments for intersection checks in angular hit.
     if change_r == 1


### PR DESCRIPTION
Add chord length test to the spherical case. The logic is similar to the polar one. We first find the expected chord length via the entry and exit time calculation. Then, we use an accumulator to keep track of total time we spend on traversal. 