### PR TITLE
Add multiple ray intersection benchmark, Optimize initialization of voxel boundary segments, and more.

### DIFF
--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -42,8 +42,8 @@ public:
             inv_delta_phi_(1.0 / delta_phi_) {
 
         double radians = 0;
-        P_max_angular_.resize(num_angular_voxels);
-        P_max_azimuthal_.resize(num_azimuthal_voxels);
+        P_max_angular_.resize(num_angular_voxels + 1);
+        P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
 
         if (num_angular_voxels == num_azimuthal_voxels) {
             for (std::size_t i = 0; i < num_angular_voxels; ++i) {

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -4,7 +4,7 @@
 #include "vec3.h"
 #include <vector>
 
-// Represents a line segment. This is most commonly used to represent the points of intersections between
+// Represents a line segment. This is used to represent the points of intersections between
 // the lines corresponding to voxel boundaries and a given radial voxel.
 struct LineSegment {
     double P1;

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -2,6 +2,14 @@
 #define SPHERICAL_VOLUME_RENDERING_SPHERICALVOXELGRID_H
 
 #include "vec3.h"
+#include <vector>
+
+// Represents a line segment. This is most commonly used to represent the points of intersections between
+// the lines corresponding to voxel boundaries and a given radial voxel.
+struct LineSegment {
+    double P1;
+    double P2;
+};
 
 // Represents a 3-dimensional spherical voxel grid. The minimum and maximum bounds [min_bound_, max_bound_]
 // contain the entirety of the sphere that is to be traversed.
@@ -31,7 +39,36 @@ public:
             delta_phi_(2 * M_PI * inv_num_azimuthal_voxels_),
             inv_delta_radius_(1.0 / delta_radius_),
             inv_delta_theta_(1.0 / delta_theta_),
-            inv_delta_phi_(1.0 / delta_phi_) {}
+            inv_delta_phi_(1.0 / delta_phi_) {
+
+        double radians = 0;
+        P_max_angular_.resize(num_angular_voxels);
+        P_max_azimuthal_.resize(num_azimuthal_voxels);
+
+        if (num_angular_voxels == num_azimuthal_voxels) {
+            for (std::size_t i = 0; i < num_angular_voxels; ++i) {
+                const double px_max_value = sphere_max_radius * std::cos(radians) + sphere_center.x();
+                const double max_radius_times_s = sphere_max_radius * std::sin(radians);
+                P_max_angular_[i].P1 = px_max_value;
+                P_max_angular_[i].P2 = max_radius_times_s + sphere_center.y();
+                P_max_azimuthal_[i].P1 = px_max_value;
+                P_max_azimuthal_[i].P2 = max_radius_times_s + sphere_center.z();
+                radians += delta_phi_;
+            }
+            return;
+        }
+        for (std::size_t j = 0; j < num_angular_voxels; ++j) {
+            P_max_angular_[j].P1 = sphere_max_radius * std::cos(radians) + sphere_center.x();
+            P_max_angular_[j].P2 = sphere_max_radius * std::sin(radians) + sphere_center.y();
+            radians += delta_theta_;
+        }
+        radians = 0;
+        for (std::size_t k = 0; k < num_azimuthal_voxels; ++k) {
+            P_max_azimuthal_[k].P1 = sphere_max_radius * std::cos(radians) + sphere_center.x();
+            P_max_azimuthal_[k].P2 = sphere_max_radius * std::sin(radians) + sphere_center.z();
+            radians += delta_phi_;
+        }
+    }
 
     inline std::size_t numRadialVoxels() const { return num_radial_voxels_; }
 
@@ -65,6 +102,14 @@ public:
 
     inline double invDeltaPhi() const { return inv_delta_phi_; }
 
+    inline LineSegment pMaxAngular(int i) const { return P_max_angular_[i]; }
+
+    inline const std::vector<LineSegment>& pMaxAngular() const { return P_max_angular_; }
+
+    inline const LineSegment pMaxAzimuthal(int i) const { return P_max_azimuthal_[i]; }
+
+    inline const std::vector<LineSegment>& pMaxAzimuthal() const { return P_max_azimuthal_; }
+
 private:
     // The minimum bound vector of the voxel grid.
     const BoundVec3 min_bound_;
@@ -92,6 +137,12 @@ private:
 
     // Inverse of the above delta values.
     const double inv_delta_radius_, inv_delta_theta_, inv_delta_phi_;
+
+    // The maximum radius line segments for angular voxels.
+    std::vector<LineSegment> P_max_angular_;
+
+    // The maximum radius line segments for azimuthal voxels.
+    std::vector<LineSegment> P_max_azimuthal_;
 };
 
 #endif //SPHERICAL_VOLUME_RENDERING_SPHERICALVOXELGRID_H

--- a/cpp/testing/benchmarking.cpp
+++ b/cpp/testing/benchmarking.cpp
@@ -130,11 +130,39 @@ static void MultipleRayNoIntersection(benchmark::State& state) {
     }
 }
 
+static void MultipleRayIntersection(benchmark::State& state) {
+    for (auto _ : state) {
+        const int number_of_rays = 10;
+        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10000.0;
+        const std::size_t num_radial_sections = 10000;
+        const std::size_t num_angular_sections = 10000;
+        const std::size_t num_azimuthal_sections = 10000;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = 100000.0;
+
+        double ray_origin_x = -5000.0;
+        for (int i = 0; i < number_of_rays; ++i) {
+            const BoundVec3 ray_origin(ray_origin_x, 0.0, 0.0);
+            const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+            const Ray ray(ray_origin, ray_direction);
+            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+            ray_origin_x += 1000.0;
+        }
+    }
+}
+
 BENCHMARK(TraversalOne)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalTwo)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalParallelX)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
 BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
+BENCHMARK(MultipleRayIntersection)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
- Added a benchmark for multiple ray intersection.
- Optimized the initialization of voxel boundary segments; Since the boundary segments for the maximum radius will be the same for all rays through a similar sphere, this can be done in the construction of the SphericalVoxelGrid.
- In CalculateVoxelID(), I was using ```const std::vector``` instead of ```const std::vector &``` which was creating a copy on each call. Fixing this bug allowed for a major speedup.