### PR TITLE
Add namespaces, optimize Ray functions, add orthographic benchmark.

### DIFF
--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -1,7 +1,6 @@
 #ifndef SPHERICAL_VOLUME_RENDERING_RAY_H
 #define SPHERICAL_VOLUME_RENDERING_RAY_H
 
-#include <array>
 #include "vec3.h"
 
 // The indices for Vec3. For example, Vec3[0] returns the x-direction.

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -4,6 +4,7 @@
 #include <array>
 #include "vec3.h"
 
+// The indices for Vec3. For example, Vec3[0] returns the x-direction.
 enum NonZeroDirectionIndex {
   X_DIRECTION = 0, Y_DIRECTION = 1, Z_DIRECTION = 2
 };

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -24,12 +24,12 @@ struct Ray final {
     // Represents the function p(t) = origin + t * direction,
     // where p is a 3-dimensional position, and t is a scalar.
     inline BoundVec3 pointAtParameter(const double t) const noexcept {
-        return this->origin_ + (this->direction_ * t);
+        return this->origin_ + this->direction_ * t;
     }
 
     // Returns the time of intersection at a Point p.
-    // The calculation: t = [p.a() - ray.origin().a()] / ray.unitDirection().a()
-    //                  where a is a non-zero unit direction of the ray.
+    // The calculation: t = [p.a() - ray.origin().a()] / ray.Direction().a()
+    //                  where a is a non-zero direction of the ray.
     // To reduce a vector multiplication to a single multiplication for the given direction,
     // we can do the following:
     // Since Point p = ray.origin() + ray.direction() * (v +/- discriminant),

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -1,17 +1,49 @@
 #ifndef SPHERICAL_VOLUME_RENDERING_RAY_H
 #define SPHERICAL_VOLUME_RENDERING_RAY_H
 
+#include <array>
 #include "vec3.h"
 
-// Encapsulates the functionality of a ray.
-// This consists of two components, the origin of the ray,
-// and the direction of the ray.
+enum NonZeroDirectionIndex {
+  X_DIRECTION = 0, Y_DIRECTION = 1, Z_DIRECTION = 2
+};
+
+// This struct provides parameters for division by a non-zero direction.
+// This avoids the need to check if the direction is non-zero each time a function below is called.
+struct NonZeroDirectionParameters {
+  double inv_direction;
+  double unit_direction;
+  double origin;
+  NonZeroDirectionIndex index;
+};
+
+// Encapsulates the functionality of a ray. This consists of two components, the origin of the ray, and the
+// direction of the ray. To avoid checking for a non-zero direction upon each function call, these parameters are
+// initialized upon construction.
 struct Ray final {
     Ray(const BoundVec3 &origin, const FreeVec3 &direction)
             : origin_(origin), direction_(direction), unit_direction_(direction),
-              inverse_direction_(FreeVec3(1.0 / direction.x(), 1.0 / direction.y(), 1.0 / direction.z())),
-              x_dir_is_non_zero_(std::abs(direction.x()) > 0.0), y_dir_is_non_zero_(std::abs(direction.y()) > 0.0),
-              z_dir_is_non_zero_(std::abs(direction.z()) > 0.0) {}
+              inverse_direction_(FreeVec3(1.0 / direction.x(), 1.0 / direction.y(), 1.0 / direction.z())) {
+
+      if (std::abs(direction.x()) > 0) {
+        NZD_params_.origin = origin.x();
+        NZD_params_.inv_direction = inverse_direction_.x();
+        NZD_params_.unit_direction = unit_direction_.x();
+        NZD_params_.index = X_DIRECTION;
+        return;
+      }
+      if (std::abs(direction.y()) > 0) {
+        NZD_params_.origin = origin.y();
+        NZD_params_.inv_direction = inverse_direction_.y();
+        NZD_params_.unit_direction = unit_direction_.y();
+        NZD_params_.index = Y_DIRECTION;
+        return;
+      }
+      NZD_params_.origin = origin.z();
+      NZD_params_.inv_direction = inverse_direction_.z();
+      NZD_params_.unit_direction = unit_direction_.z();
+      NZD_params_.index = Z_DIRECTION;
+    }
 
     // Represents the function p(t) = origin + t * direction,
     // where p is a 3-dimensional position, and t is a scalar.
@@ -27,27 +59,12 @@ struct Ray final {
     // Since Point p = ray.origin() + ray.direction() * (v +/- discriminant),
     // We can simply provide the difference or addition of v and the discriminant.
     inline double timeOfIntersectionAt(double discriminant_v) const noexcept {
-        if (xDirectionIsNonZero()) {
-            const double p_x = origin().x() + unitDirection().x() * discriminant_v;
-            return (p_x - origin().x()) * invDirection().x();
-        }
-        if (yDirectionIsNonZero()) {
-            const double p_y = origin().y() + unitDirection().y() * discriminant_v;
-            return (p_y - origin().y()) * invDirection().y();
-        }
-        const double p_z = origin().z() + unitDirection().z() * discriminant_v;
-        return (p_z - origin().z()) * invDirection().z();
+      return (NZD_params_.unit_direction * discriminant_v) * NZD_params_.inv_direction;
     }
 
     // Similar to above implementation, but uses a given vector p.
     inline double timeOfIntersectionAt(const Vec3 &p) const noexcept {
-        if (xDirectionIsNonZero()) {
-            return (p.x() - origin().x()) * invDirection().x();
-        }
-        if (yDirectionIsNonZero()) {
-            return (p.y() - origin().y()) * invDirection().y();
-        }
-        return (p.z() - origin().z()) * invDirection().z();
+      return (p[NZD_params_.index] - NZD_params_.origin) * NZD_params_.inv_direction;
     }
 
     inline BoundVec3 origin() const noexcept { return this->origin_; }
@@ -58,23 +75,21 @@ struct Ray final {
 
     inline UnitVec3 unitDirection() const noexcept { return this->unit_direction_; }
 
-    inline bool xDirectionIsNonZero() const noexcept { return this->x_dir_is_non_zero_; }
-
-    inline bool yDirectionIsNonZero() const noexcept { return this->y_dir_is_non_zero_; }
-
-    inline bool zDirectionIsNonZero() const noexcept { return this->z_dir_is_non_zero_; }
-
 private:
     // The origin of the ray.
     const BoundVec3 origin_;
+
     // The direction of the ray.
     const FreeVec3 direction_;
+
     // The normalized direction of the ray.
     const UnitVec3 unit_direction_;
+
     // The inverse direction of the ray.
     const FreeVec3 inverse_direction_;
-    // Determines whether the given direction is non-zero to avoid division by 0.
-    const bool x_dir_is_non_zero_, y_dir_is_non_zero_, z_dir_is_non_zero_;
+
+    // Non-zero direction parameters.
+    NonZeroDirectionParameters NZD_params_;
 };
 
 #endif //SPHERICAL_VOLUME_RENDERING_RAY_H

--- a/cpp/ray.h
+++ b/cpp/ray.h
@@ -5,7 +5,9 @@
 
 // The indices for Vec3. For example, Vec3[0] returns the x-direction.
 enum NonZeroDirectionIndex {
-  X_DIRECTION = 0, Y_DIRECTION = 1, Z_DIRECTION = 2
+  X_DIRECTION = 0,
+  Y_DIRECTION = 1,
+  Z_DIRECTION = 2
 };
 
 // Encapsulates the functionality of a ray. This consists of two components, the origin of the ray, and the
@@ -65,7 +67,7 @@ private:
     const FreeVec3 inverse_direction_;
 
     // Index of a non-zero direction.
-    NonZeroDirectionIndex NZD_index_;
+    const NonZeroDirectionIndex NZD_index_;
 
     // The non-zero direction values to avoid using the [] operator with each function call.
     const double NZD_origin_, NZD_inverse_direction_, NZD_unit_direction_;

--- a/cpp/spherical_volume_rendering_util.cpp
+++ b/cpp/spherical_volume_rendering_util.cpp
@@ -5,96 +5,99 @@
 #include <cmath>
 #include <limits>
 
+namespace SVR {
+
 // Epsilons used for floating point comparisons in Knuth's algorithm.
-const double ABS_EPSILON = 1e-12;
-const double REL_EPSILON = 1e-8;
+    const double ABS_EPSILON = 1e-12;
+    const double REL_EPSILON = 1e-8;
 
 // The type corresponding to the voxel(s) with the minimum tMax value for a given traversal.
-enum VoxelIntersectionType {
-    None = 0,
-    Radial = 1,
-    Angular = 2,
-    Azimuthal = 3,
-    RadialAngular = 4,
-    RadialAzimuthal = 5,
-    AngularAzimuthal = 6,
-    RadialAngularAzimuthal = 7
-};
+    enum VoxelIntersectionType {
+        None = 0,
+        Radial = 1,
+        Angular = 2,
+        Azimuthal = 3,
+        RadialAngular = 4,
+        RadialAzimuthal = 5,
+        AngularAzimuthal = 6,
+        RadialAngularAzimuthal = 7
+    };
 
 // The parameters returned by radialHit().
-struct RadialHitParameters {
-    // The time at which a hit occurs for the ray at the next point of intersection with a radial section.
-    // This is always calculated from the ray origin.
-    double tMaxR;
+    struct RadialHitParameters {
+        // The time at which a hit occurs for the ray at the next point of intersection with a radial section.
+        // This is always calculated from the ray origin.
+        double tMaxR;
 
-    // The voxel traversal value of a radial step: 0, +1, -1. This is added to the current radial voxel.
-    int tStepR;
+        // The voxel traversal value of a radial step: 0, +1, -1. This is added to the current radial voxel.
+        int tStepR;
 
-    // Determine whether the current voxel traversal was a 'transition'. This is necessary to determine when
-    // The radial steps should go from negative to positive or vice-versa,
-    // since the radial voxels go from 1..N, where N is the number of radial sections.
-    bool previous_transition_flag;
+        // Determine whether the current voxel traversal was a 'transition'. This is necessary to determine when
+        // The radial steps should go from negative to positive or vice-versa,
+        // since the radial voxels go from 1..N, where N is the number of radial sections.
+        bool previous_transition_flag;
 
-    // Determines whether the current hit is within time bounds (t, t_end).
-    bool within_bounds;
+        // Determines whether the current hit is within time bounds (t, t_end).
+        bool within_bounds;
 
-    // Determines whether the current voxel hit has caused a step outside of the spherical voxel grid.
-    bool exits_voxel_bounds;
-};
+        // Determines whether the current voxel hit has caused a step outside of the spherical voxel grid.
+        bool exits_voxel_bounds;
+    };
 
 // The parameters returned by angularHit().
-struct AngularHitParameters {
-    // The time at which a hit occurs for the ray at the next point of intersection with an angular section.
-    // This is always calculated from the ray origin.
-    double tMaxTheta;
+    struct AngularHitParameters {
+        // The time at which a hit occurs for the ray at the next point of intersection with an angular section.
+        // This is always calculated from the ray origin.
+        double tMaxTheta;
 
-    // The voxel traversal value of an angular step: 0, +1, -1. This is added to the current angular voxel.
-    int tStepTheta;
+        // The voxel traversal value of an angular step: 0, +1, -1. This is added to the current angular voxel.
+        int tStepTheta;
 
-    // Determines whether the current hit is within time bounds (t, t_end).
-    bool within_bounds;
-};
+        // Determines whether the current hit is within time bounds (t, t_end).
+        bool within_bounds;
+    };
 
 // The parameters returned by azimuthalHit().
-struct AzimuthalHitParameters {
-    // The time at which a hit occurs for the ray at the next point of intersection with an azimuthal section.
-    // This is always calculated from the ray origin.
-    double tMaxPhi;
+    struct AzimuthalHitParameters {
+        // The time at which a hit occurs for the ray at the next point of intersection with an azimuthal section.
+        // This is always calculated from the ray origin.
+        double tMaxPhi;
 
-    // The voxel traversal value of an azimuthal step: 0, +1, -1. This is added to the current azimuthal voxel.
-    int tStepPhi;
+        // The voxel traversal value of an azimuthal step: 0, +1, -1. This is added to the current azimuthal voxel.
+        int tStepPhi;
 
-    // Determines whether the current hit is within time bounds (t, t_end).
-    bool within_bounds;
-};
+        // Determines whether the current hit is within time bounds (t, t_end).
+        bool within_bounds;
+    };
 
 // A generalized set of hit parameters.
-struct GenHitParameters {
-    double tMax;
-    int tStep;
-    bool within_bounds;
-};
+    struct GenHitParameters {
+        double tMax;
+        int tStep;
+        bool within_bounds;
+    };
 
 // The necessary information to calculate a radial hit. ray_sphere_vector_dot and v are calculated
 // in the initialization phase, so unnecessary to re-calculate again for radial hit. intersection_times and times_gt_t
 // are used to determine the type of radial hit. Upon initialization, the previous transition flag is set to false.
-struct RadialHitData {
-    inline RadialHitData(double t_v, double t_ray_sphere_vector_dot) :
-    v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot) {
-        times_gt_t.reserve(4);
-        previous_transition_flag = false;
-    }
-    double v, ray_sphere_vector_dot;
-    std::array<double, 4> intersection_times;
-    std::vector<double> times_gt_t;
-    bool previous_transition_flag;
-};
+    struct RadialHitData {
+        inline RadialHitData(double t_v, double t_ray_sphere_vector_dot) :
+                v(t_v), ray_sphere_vector_dot(t_ray_sphere_vector_dot) {
+            times_gt_t.reserve(4);
+            previous_transition_flag = false;
+        }
 
-template <class T>
-inline T MAX(const T& a, const T& b) noexcept { return a > b ? a : b; }
+        double v, ray_sphere_vector_dot;
+        std::array<double, 4> intersection_times;
+        std::vector<double> times_gt_t;
+        bool previous_transition_flag;
+    };
 
-template <class T>
-inline T MIN(const T& a, const T& b) noexcept { return a < b ? a : b; }
+    template<class T>
+    inline T MAX(const T &a, const T &b) noexcept { return a > b ? a : b; }
+
+    template<class T>
+    inline T MIN(const T &a, const T &b) noexcept { return a < b ? a : b; }
 
 // Determines equality between two floating point numbers in two steps. First, it uses the absolute epsilon, then it
 // uses a modified version of an algorithm developed by Donald Knuth (which in turn relies upon relative epsilon).
@@ -105,128 +108,128 @@ inline T MIN(const T& a, const T& b) noexcept { return a < b ? a : b; }
 // Related reading:
 //        Donald. E. Knuth, 1998, Addison-Wesley Longman, Inc., ISBN 0-201-89684-2, Addison-Wesley Professional;
 //        3rd edition. (The relevant equations are in §4.2.2, Eq. 36 and 37.)
-inline bool isKnEqual(double a, double b) noexcept {
-    const double diff = std::abs(a - b);
-    if (diff <= ABS_EPSILON) { return true; }
-    return diff <= MAX(std::abs(a), std::abs(b)) * REL_EPSILON;
-}
+    inline bool isKnEqual(double a, double b) noexcept {
+        const double diff = std::abs(a - b);
+        if (diff <= ABS_EPSILON) { return true; }
+        return diff <= MAX(std::abs(a), std::abs(b)) * REL_EPSILON;
+    }
 
 // Overloaded version that checks for Knuth equality with vector cartesian coordinates.
-inline bool isKnEqual(const Vec3 &a, const Vec3 &b) noexcept {
-    const double diff_x = std::abs(a.x() - b.x());
-    const double diff_y = std::abs(a.y() - b.y());
-    const double diff_z = std::abs(a.z() - b.z());
-    if (diff_x <= ABS_EPSILON && diff_y <= ABS_EPSILON && diff_z <= ABS_EPSILON) { return true; }
-    return diff_x <= MAX(std::abs(a.x()), std::abs(b.x())) * REL_EPSILON &&
-           diff_y <= MAX(std::abs(a.y()), std::abs(b.y())) * REL_EPSILON &&
-           diff_z <= MAX(std::abs(a.z()), std::abs(b.z())) * REL_EPSILON;
-}
+    inline bool isKnEqual(const Vec3 &a, const Vec3 &b) noexcept {
+        const double diff_x = std::abs(a.x() - b.x());
+        const double diff_y = std::abs(a.y() - b.y());
+        const double diff_z = std::abs(a.z() - b.z());
+        if (diff_x <= ABS_EPSILON && diff_y <= ABS_EPSILON && diff_z <= ABS_EPSILON) { return true; }
+        return diff_x <= MAX(std::abs(a.x()), std::abs(b.x())) * REL_EPSILON &&
+               diff_y <= MAX(std::abs(a.y()), std::abs(b.y())) * REL_EPSILON &&
+               diff_z <= MAX(std::abs(a.z()), std::abs(b.z())) * REL_EPSILON;
+    }
 
 // Uses the Knuth algorithm in KnEqual() to ensure that a is strictly less than b.
-inline bool KnLessThan(double a, double b) noexcept {
-    return a < b && !isKnEqual(a, b);
-}
+    inline bool KnLessThan(double a, double b) noexcept {
+        return a < b && !isKnEqual(a, b);
+    }
 
 // A point will lie between two angular voxel boundaries iff the angle between it and the angular boundary intersection
 // points along the circle of max radius is obtuse. Equality represents the case when the point lies on an angular
 // boundary. This is similar for azimuthal boundaries. Since both cases use points in a plane (XY for angular, XZ
 // for azimuthal), this can be generalized to a single function. Since angular and azimuthal voxel boundaries range from
 // [0, N], returns -1 in the case where the point does not lie within the boundaries.
-inline int calculateVoxelID(const std::vector<LineSegment> &plane, double p1, double p2) noexcept {
-    std::size_t i = 0;
-    while (i < plane.size() - 1) {
-        const double px_diff = plane[i].P1 - plane[i + 1].P1;
-        const double py_diff = plane[i].P2 - plane[i + 1].P2;
-        const double px_p1_diff = plane[i].P1 - p1;
-        const double py_p1_diff = plane[i].P2 - p2;
-        const double n_px_p1_diff = plane[i + 1].P1 - p1;
-        const double n_py_p1_diff = plane[i + 1].P2 - p2;
-        const double d1d2 = (px_p1_diff * px_p1_diff) + (py_p1_diff * py_p1_diff) +
-                            (n_px_p1_diff * n_px_p1_diff) + (n_py_p1_diff * n_py_p1_diff);
-        const double d3 = (px_diff * px_diff) + (py_diff * py_diff);
-        if (KnLessThan(d1d2, d3) || isKnEqual(d1d2, d3)) { return i; }
-        ++i;
+    inline int calculateVoxelID(const std::vector<SVR::LineSegment> &plane, double p1, double p2) noexcept {
+        std::size_t i = 0;
+        while (i < plane.size() - 1) {
+            const double px_diff = plane[i].P1 - plane[i + 1].P1;
+            const double py_diff = plane[i].P2 - plane[i + 1].P2;
+            const double px_p1_diff = plane[i].P1 - p1;
+            const double py_p1_diff = plane[i].P2 - p2;
+            const double n_px_p1_diff = plane[i + 1].P1 - p1;
+            const double n_py_p1_diff = plane[i + 1].P2 - p2;
+            const double d1d2 = (px_p1_diff * px_p1_diff) + (py_p1_diff * py_p1_diff) +
+                                (n_px_p1_diff * n_px_p1_diff) + (n_py_p1_diff * n_py_p1_diff);
+            const double d3 = (px_diff * px_diff) + (py_diff * py_diff);
+            if (KnLessThan(d1d2, d3) || isKnEqual(d1d2, d3)) { return i; }
+            ++i;
+        }
+        return -1;
     }
-    return -1;
-}
 
 // Determines whether a radial hit occurs for the given ray. A radial hit is considered an intersection with
 // the ray and a radial section. This follows closely the mathematics presented in:
 // http://cas.xav.free.fr/Graphics%20Gems%204%20-%20Paul%20S.%20Heckbert.pdf
 // The struct RadialHitData is used to provide already initialized data structures, as well as avoiding unnecessary
 // duplicate calculations that have already been done in the initialization phase.
-RadialHitParameters radialHit(const Ray &ray, const SphericalVoxelGrid &grid, RadialHitData& data,
-                              int current_voxel_ID_r, double t, double t_end) noexcept {
-    const double current_radius = grid.sphereMaxRadius() - grid.deltaRadius() * (current_voxel_ID_r - 1);
-    double r_a = MAX(current_radius - grid.deltaRadius(), grid.deltaRadius());
-    double r_b;
-    if (!data.previous_transition_flag) {
-        // To find the next radius, we need to check the previous_transition_flag:
-        // In the case that the ray has sequential hits with equal radii, e.g.
-        // the innermost radial disc, this ensures that the proper radii are being checked.
-        r_b = MIN(current_radius + grid.deltaRadius(), grid.sphereMaxRadius());
-    } else { r_b = MIN(current_radius, grid.sphereMaxRadius()); }
-    // Find the intersection times for the ray and the previous and next radial discs.
-    const double ray_sphere_dot_minus_v_squared = data.ray_sphere_vector_dot - data.v * data.v;
-    double discriminant_a = r_a * r_a - ray_sphere_dot_minus_v_squared;
-    if (discriminant_a < 0.0) {
-        r_a += grid.deltaRadius();
-        discriminant_a = r_a * r_a - ray_sphere_dot_minus_v_squared;
+    RadialHitParameters radialHit(const Ray &ray, const SVR::SphericalVoxelGrid &grid, RadialHitData &data,
+                                  int current_voxel_ID_r, double t, double t_end) noexcept {
+        const double current_radius = grid.sphereMaxRadius() - grid.deltaRadius() * (current_voxel_ID_r - 1);
+        double r_a = MAX(current_radius - grid.deltaRadius(), grid.deltaRadius());
+        double r_b;
+        if (!data.previous_transition_flag) {
+            // To find the next radius, we need to check the previous_transition_flag:
+            // In the case that the ray has sequential hits with equal radii, e.g.
+            // the innermost radial disc, this ensures that the proper radii are being checked.
+            r_b = MIN(current_radius + grid.deltaRadius(), grid.sphereMaxRadius());
+        } else { r_b = MIN(current_radius, grid.sphereMaxRadius()); }
+        // Find the intersection times for the ray and the previous and next radial discs.
+        const double ray_sphere_dot_minus_v_squared = data.ray_sphere_vector_dot - data.v * data.v;
+        double discriminant_a = r_a * r_a - ray_sphere_dot_minus_v_squared;
+        if (discriminant_a < 0.0) {
+            r_a += grid.deltaRadius();
+            discriminant_a = r_a * r_a - ray_sphere_dot_minus_v_squared;
+        }
+        const double d_a = std::sqrt(discriminant_a);
+
+        data.intersection_times[0] = ray.timeOfIntersectionAt(data.v - d_a);
+        data.intersection_times[1] = ray.timeOfIntersectionAt(data.v + d_a);
+
+        const double discriminant_b = r_b * r_b - ray_sphere_dot_minus_v_squared;
+        if (discriminant_b >= 0.0) {
+            const double d_b = std::sqrt(discriminant_b);
+            data.intersection_times[2] = ray.timeOfIntersectionAt(data.v - d_b);
+            data.intersection_times[3] = ray.timeOfIntersectionAt(data.v + d_b);
+        } else {
+            data.intersection_times[2] = 0.0;
+            data.intersection_times[3] = 0.0;
+        }
+        data.times_gt_t.clear();
+        std::copy_if(data.intersection_times.cbegin(), data.intersection_times.cend(),
+                     std::back_inserter(data.times_gt_t), [t](double i) { return i > t; });
+        RadialHitParameters radial_params;
+        bool t_within_bounds = false;
+        if (data.times_gt_t.size() >= 2 && isKnEqual(data.intersection_times[0], data.intersection_times[1])) {
+            // Ray is tangent to the circle, i.e. two intersection times are equal.
+            radial_params.tMaxR = data.times_gt_t[0];
+            const BoundVec3 p = ray.pointAtParameter(radial_params.tMaxR);
+            const double p_x_new = p.x() - grid.sphereCenter().x();
+            const double p_y_new = p.y() - grid.sphereCenter().y();
+            const double p_z_new = p.z() - grid.sphereCenter().z();
+            const double r_new = std::sqrt(p_x_new * p_x_new + p_y_new * p_y_new + p_z_new * p_z_new);
+
+            radial_params.tStepR = 0;
+            t_within_bounds = KnLessThan(t, radial_params.tMaxR) && KnLessThan(radial_params.tMaxR, t_end);
+            radial_params.previous_transition_flag = isKnEqual(current_radius, r_new);
+        } else if (data.times_gt_t.empty()) {
+            // No intersection.
+            radial_params.tMaxR = std::numeric_limits<double>::infinity();
+            radial_params.tStepR = 0;
+            radial_params.previous_transition_flag = false;
+        } else {
+            // Radial intersection.
+            radial_params.tMaxR = data.times_gt_t[0];
+            const BoundVec3 p = ray.pointAtParameter(radial_params.tMaxR);
+            const double p_x_new = p.x() - grid.sphereCenter().x();
+            const double p_y_new = p.y() - grid.sphereCenter().y();
+            const double p_z_new = p.z() - grid.sphereCenter().z();
+            const double r_new = std::sqrt(p_x_new * p_x_new + p_y_new * p_y_new + p_z_new * p_z_new);
+
+            const bool radial_difference_is_near_zero = isKnEqual(r_new, current_radius);
+            radial_params.previous_transition_flag = radial_difference_is_near_zero;
+            radial_params.tStepR = (KnLessThan(r_new, current_radius) && !radial_difference_is_near_zero) ? 1 : -1;
+            t_within_bounds = KnLessThan(t, radial_params.tMaxR) && KnLessThan(radial_params.tMaxR, t_end);
+        }
+        radial_params.exits_voxel_bounds = (current_voxel_ID_r + radial_params.tStepR) == 0;
+        radial_params.within_bounds = t_within_bounds && !radial_params.exits_voxel_bounds;
+        return radial_params;
     }
-    const double d_a = std::sqrt(discriminant_a);
-
-    data.intersection_times[0] = ray.timeOfIntersectionAt(data.v - d_a);
-    data.intersection_times[1] = ray.timeOfIntersectionAt(data.v + d_a);
-
-    const double discriminant_b = r_b * r_b - ray_sphere_dot_minus_v_squared;
-    if (discriminant_b >= 0.0) {
-        const double d_b = std::sqrt(discriminant_b);
-        data.intersection_times[2] = ray.timeOfIntersectionAt(data.v - d_b);
-        data.intersection_times[3] = ray.timeOfIntersectionAt(data.v + d_b);
-    } else {
-        data.intersection_times[2] = 0.0;
-        data.intersection_times[3] = 0.0;
-    }
-    data.times_gt_t.clear();
-    std::copy_if(data.intersection_times.cbegin(), data.intersection_times.cend(),
-                 std::back_inserter(data.times_gt_t), [t](double i) { return i > t; });
-    RadialHitParameters radial_params;
-    bool t_within_bounds = false;
-    if (data.times_gt_t.size() >= 2 && isKnEqual(data.intersection_times[0], data.intersection_times[1])) {
-        // Ray is tangent to the circle, i.e. two intersection times are equal.
-        radial_params.tMaxR = data.times_gt_t[0];
-        const BoundVec3 p = ray.pointAtParameter(radial_params.tMaxR);
-        const double p_x_new = p.x() - grid.sphereCenter().x();
-        const double p_y_new = p.y() - grid.sphereCenter().y();
-        const double p_z_new = p.z() - grid.sphereCenter().z();
-        const double r_new = std::sqrt(p_x_new * p_x_new + p_y_new * p_y_new + p_z_new * p_z_new);
-
-        radial_params.tStepR = 0;
-        t_within_bounds = KnLessThan(t, radial_params.tMaxR) && KnLessThan(radial_params.tMaxR, t_end);
-        radial_params.previous_transition_flag = isKnEqual(current_radius, r_new);
-    } else if (data.times_gt_t.empty()) {
-        // No intersection.
-        radial_params.tMaxR = std::numeric_limits<double>::infinity();
-        radial_params.tStepR = 0;
-        radial_params.previous_transition_flag = false;
-    } else {
-        // Radial intersection.
-        radial_params.tMaxR = data.times_gt_t[0];
-        const BoundVec3 p = ray.pointAtParameter(radial_params.tMaxR);
-        const double p_x_new = p.x() - grid.sphereCenter().x();
-        const double p_y_new = p.y() - grid.sphereCenter().y();
-        const double p_z_new = p.z() - grid.sphereCenter().z();
-        const double r_new = std::sqrt(p_x_new * p_x_new + p_y_new * p_y_new + p_z_new * p_z_new);
-
-        const bool radial_difference_is_near_zero = isKnEqual(r_new, current_radius);
-        radial_params.previous_transition_flag = radial_difference_is_near_zero;
-        radial_params.tStepR = (KnLessThan(r_new, current_radius) && !radial_difference_is_near_zero) ? 1 : -1;
-        t_within_bounds = KnLessThan(t, radial_params.tMaxR) && KnLessThan(radial_params.tMaxR, t_end);
-    }
-    radial_params.exits_voxel_bounds = (current_voxel_ID_r + radial_params.tStepR) == 0;
-    radial_params.within_bounds = t_within_bounds && !radial_params.exits_voxel_bounds;
-    return radial_params;
-}
 
 // A generalized version of the latter half of the angular and azimuthal hit parameters. Since the only difference
 // is the 2-d plane for which they exist in, this portion can be generalized to a single function call. The variables
@@ -234,148 +237,157 @@ RadialHitParameters radialHit(const Ray &ray, const SphericalVoxelGrid &grid, Ra
 // ray_plane_direction == ray.direction.y(). The calculations presented below follow closely the
 // works of [Foley et al, 1996], [O'Rourke, 1998].
 // Reference: http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
-GenHitParameters generalizedPlaneHit(const SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min, double perp_uv_max,
-                                     double perp_uw_min, double perp_uw_max, double perp_vw_min, double perp_vw_max,
-                                     const BoundVec3 &p, const FreeVec3 &v, double t, double t_end,
-                                     double ray_plane_direction, double sphere_plane_center,
-                                     const std::vector<LineSegment> &P_max, int current_voxel_ID) noexcept {
-    const bool is_parallel_min = isKnEqual(perp_uv_min, 0.0);
-    const bool is_collinear_min = is_parallel_min && isKnEqual(perp_uw_min, 0.0) && isKnEqual(perp_vw_min, 0.0);
-    const bool is_parallel_max = isKnEqual(perp_uv_max, 0.0);
-    const bool is_collinear_max = is_parallel_max && isKnEqual(perp_uw_max, 0.0) && isKnEqual(perp_vw_max, 0.0);
-    double a, b;
-    double t_min = is_collinear_min ? ray.timeOfIntersectionAt(grid.sphereCenter()) : 0.0;
-    bool is_intersect_min = false;
-    if (!is_parallel_min) {
-        const double inv_perp_uv_min = 1.0 / perp_uv_min;
-        a = perp_vw_min * inv_perp_uv_min;
-        b = perp_uw_min * inv_perp_uv_min;
-        if ( !((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b)) ) {
-            is_intersect_min = true;
-            t_min = ray.timeOfIntersectionAt(Vec3(p.x() + v.x() * b, p.y() + v.y() * b, p.z() + v.z() * b));
+    GenHitParameters
+    generalizedPlaneHit(const SVR::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min, double perp_uv_max,
+                        double perp_uw_min, double perp_uw_max, double perp_vw_min, double perp_vw_max,
+                        const BoundVec3 &p, const FreeVec3 &v, double t, double t_end,
+                        double ray_plane_direction, double sphere_plane_center,
+                        const std::vector<SVR::LineSegment> &P_max, int current_voxel_ID) noexcept {
+        const bool is_parallel_min = isKnEqual(perp_uv_min, 0.0);
+        const bool is_collinear_min = is_parallel_min && isKnEqual(perp_uw_min, 0.0) && isKnEqual(perp_vw_min, 0.0);
+        const bool is_parallel_max = isKnEqual(perp_uv_max, 0.0);
+        const bool is_collinear_max = is_parallel_max && isKnEqual(perp_uw_max, 0.0) && isKnEqual(perp_vw_max, 0.0);
+        double a, b;
+        double t_min = is_collinear_min ? ray.timeOfIntersectionAt(grid.sphereCenter()) : 0.0;
+        bool is_intersect_min = false;
+        if (!is_parallel_min) {
+            const double inv_perp_uv_min = 1.0 / perp_uv_min;
+            a = perp_vw_min * inv_perp_uv_min;
+            b = perp_uw_min * inv_perp_uv_min;
+            if (!((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b))) {
+                is_intersect_min = true;
+                t_min = ray.timeOfIntersectionAt(Vec3(p.x() + v.x() * b, p.y() + v.y() * b, p.z() + v.z() * b));
+            }
         }
-    }
-    double t_max = is_collinear_max ? ray.timeOfIntersectionAt(grid.sphereCenter()) : 0.0;
-    bool is_intersect_max = false;
-    if (!is_parallel_max) {
-        const double inv_perp_uv_max = 1.0 / perp_uv_max;
-        a = perp_vw_max * inv_perp_uv_max;
-        b = perp_uw_max * inv_perp_uv_max;
-        if (! ((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b)) ) {
-            is_intersect_max = true;
-            t_max = ray.timeOfIntersectionAt(Vec3(p.x() + v.x() * b, p.y() + v.y() * b, p.z() + v.z() * b));
+        double t_max = is_collinear_max ? ray.timeOfIntersectionAt(grid.sphereCenter()) : 0.0;
+        bool is_intersect_max = false;
+        if (!is_parallel_max) {
+            const double inv_perp_uv_max = 1.0 / perp_uv_max;
+            a = perp_vw_max * inv_perp_uv_max;
+            b = perp_uw_max * inv_perp_uv_max;
+            if (!((KnLessThan(a, 0.0) || KnLessThan(1.0, a)) || KnLessThan(b, 0.0) || KnLessThan(1.0, b))) {
+                is_intersect_max = true;
+                t_max = ray.timeOfIntersectionAt(Vec3(p.x() + v.x() * b, p.y() + v.y() * b, p.z() + v.z() * b));
+            }
         }
-    }
-    GenHitParameters params;
-    if (is_intersect_max && !is_intersect_min && !is_collinear_min && KnLessThan(t_max, t_end) && KnLessThan(t, t_max)) {
-        params.tStep = 1;
-        params.tMax = t_max;
-        params.within_bounds = true;
-        return params;
-    }
-    if (is_intersect_min && !is_intersect_max && !is_collinear_max && KnLessThan(t_min, t_end) && KnLessThan(t, t_min)) {
-        params.tStep = -1;
-        params.tMax = t_min;
-        params.within_bounds = true;
-        return params;
-    }
-    if ((is_intersect_min && is_intersect_max) ||
-        (is_intersect_min && is_collinear_max) ||
-        (is_intersect_max && is_collinear_min)) {
-        const bool t_min_within_bounds = KnLessThan(t, t_min) && KnLessThan(t_min, t_end);
-        if (t_min_within_bounds && isKnEqual(t_min, t_max)) {
-            params.tMax = t_max;
-            const double perturbed_t = 0.1;
-            a = -ray.direction().x() * perturbed_t;
-            b = -ray_plane_direction * perturbed_t;
-            const double max_radius_over_plane_length = grid.sphereMaxRadius() / std::sqrt(a * a + b * b);
-            const double p1 = grid.sphereCenter().x() - max_radius_over_plane_length * a;
-            const double p2 = sphere_plane_center - max_radius_over_plane_length * b;
-            const int next_step = std::abs(current_voxel_ID - calculateVoxelID(P_max, p1, p2));
-
-            params.tStep = (KnLessThan(ray_plane_direction, 0.0) || KnLessThan(ray.direction().x(), 0.0)) ?
-                            next_step : -next_step;
-            params.within_bounds = true;
-            return params;
-        }
-        if (t_min_within_bounds && (KnLessThan(t_min, t_max) || isKnEqual(t, t_max))) {
-            params.tStep = -1;
-            params.tMax = t_min;
-            params.within_bounds = true;
-            return params;
-        }
-        const bool t_max_within_bounds = KnLessThan(t, t_max) && KnLessThan(t_max, t_end);
-        if (t_max_within_bounds && (KnLessThan(t_max, t_min) || isKnEqual(t, t_min))) {
+        GenHitParameters params;
+        if (is_intersect_max && !is_intersect_min && !is_collinear_min && KnLessThan(t_max, t_end) &&
+            KnLessThan(t, t_max)) {
             params.tStep = 1;
             params.tMax = t_max;
             params.within_bounds = true;
             return params;
         }
+        if (is_intersect_min && !is_intersect_max && !is_collinear_max && KnLessThan(t_min, t_end) &&
+            KnLessThan(t, t_min)) {
+            params.tStep = -1;
+            params.tMax = t_min;
+            params.within_bounds = true;
+            return params;
+        }
+        if ((is_intersect_min && is_intersect_max) ||
+            (is_intersect_min && is_collinear_max) ||
+            (is_intersect_max && is_collinear_min)) {
+            const bool t_min_within_bounds = KnLessThan(t, t_min) && KnLessThan(t_min, t_end);
+            if (t_min_within_bounds && isKnEqual(t_min, t_max)) {
+                params.tMax = t_max;
+                const double perturbed_t = 0.1;
+                a = -ray.direction().x() * perturbed_t;
+                b = -ray_plane_direction * perturbed_t;
+                const double max_radius_over_plane_length = grid.sphereMaxRadius() / std::sqrt(a * a + b * b);
+                const double p1 = grid.sphereCenter().x() - max_radius_over_plane_length * a;
+                const double p2 = sphere_plane_center - max_radius_over_plane_length * b;
+                const int next_step = std::abs(current_voxel_ID - calculateVoxelID(P_max, p1, p2));
+
+                params.tStep = (KnLessThan(ray_plane_direction, 0.0) || KnLessThan(ray.direction().x(), 0.0)) ?
+                               next_step : -next_step;
+                params.within_bounds = true;
+                return params;
+            }
+            if (t_min_within_bounds && (KnLessThan(t_min, t_max) || isKnEqual(t, t_max))) {
+                params.tStep = -1;
+                params.tMax = t_min;
+                params.within_bounds = true;
+                return params;
+            }
+            const bool t_max_within_bounds = KnLessThan(t, t_max) && KnLessThan(t_max, t_end);
+            if (t_max_within_bounds && (KnLessThan(t_max, t_min) || isKnEqual(t, t_min))) {
+                params.tStep = 1;
+                params.tMax = t_max;
+                params.within_bounds = true;
+                return params;
+            }
+        }
+        params.tStep = 0;
+        params.tMax = std::numeric_limits<double>::infinity();
+        params.within_bounds = false;
+        return params;
     }
-    params.tStep = 0;
-    params.tMax = std::numeric_limits<double>::infinity();
-    params.within_bounds = false;
-    return params;
-}
 
 // Determines whether an angular hit occurs for the given ray. An angular hit is considered an intersection with
 // the ray and an angular section. The angular sections live in the XY plane.
-AngularHitParameters angularHit(const Ray &ray, const SphericalVoxelGrid &grid,
-                                int current_voxel_ID_theta, double t, double t_end) noexcept {
-    // Ray segment vector.
-    const BoundVec3 p = ray.pointAtParameter(t);
-    const BoundVec3 p_end = ray.pointAtParameter(t_end);
-    const FreeVec3 v = p_end - p;
+    AngularHitParameters angularHit(const Ray &ray, const SVR::SphericalVoxelGrid &grid,
+                                    int current_voxel_ID_theta, double t, double t_end) noexcept {
+        // Ray segment vector.
+        const BoundVec3 p = ray.pointAtParameter(t);
+        const BoundVec3 p_end = ray.pointAtParameter(t_end);
+        const FreeVec3 v = p_end - p;
 
-    // Calculate the voxel boundary vectors.
-    const FreeVec3 p_one(grid.pMaxAngular(current_voxel_ID_theta).P1,
-                         grid.pMaxAngular(current_voxel_ID_theta).P2, 0.0);
-    const FreeVec3 p_two(grid.pMaxAngular(current_voxel_ID_theta+1).P1,
-                         grid.pMaxAngular(current_voxel_ID_theta+1).P2, 0.0);
-    const BoundVec3 u_min = grid.sphereCenter() - p_one;
-    const BoundVec3 u_max = grid.sphereCenter() - p_two;
-    const FreeVec3 w_min = p_one - FreeVec3(p);
-    const FreeVec3 w_max = p_two - FreeVec3(p);
-    const double perp_uv_min = u_min.x() * v.y() - u_min.y() * v.x();
-    const double perp_uv_max = u_max.x() * v.y() - u_max.y() * v.x();
-    const double perp_uw_min = u_min.x() * w_min.y() - u_min.y() * w_min.x();
-    const double perp_uw_max = u_max.x() * w_max.y() - u_max.y() * w_max.x();
-    const double perp_vw_min = v.x() * w_min.y() - v.y() * w_min.x();
-    const double perp_vw_max = v.x() * w_max.y() - v.y() * w_max.x();
-    const GenHitParameters params = generalizedPlaneHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min, perp_uw_max,
-                                                        perp_vw_min, perp_vw_max, p, v, t, t_end, ray.direction().y(),
-                                                        grid.sphereCenter().y(), grid.pMaxAngular(), current_voxel_ID_theta);
-    return {.tMaxTheta=params.tMax, .tStepTheta=params.tStep, .within_bounds=params.within_bounds};
-}
+        // Calculate the voxel boundary vectors.
+        const FreeVec3 p_one(grid.pMaxAngular(current_voxel_ID_theta).P1,
+                             grid.pMaxAngular(current_voxel_ID_theta).P2, 0.0);
+        const FreeVec3 p_two(grid.pMaxAngular(current_voxel_ID_theta + 1).P1,
+                             grid.pMaxAngular(current_voxel_ID_theta + 1).P2, 0.0);
+        const BoundVec3 u_min = grid.sphereCenter() - p_one;
+        const BoundVec3 u_max = grid.sphereCenter() - p_two;
+        const FreeVec3 w_min = p_one - FreeVec3(p);
+        const FreeVec3 w_max = p_two - FreeVec3(p);
+        const double perp_uv_min = u_min.x() * v.y() - u_min.y() * v.x();
+        const double perp_uv_max = u_max.x() * v.y() - u_max.y() * v.x();
+        const double perp_uw_min = u_min.x() * w_min.y() - u_min.y() * w_min.x();
+        const double perp_uw_max = u_max.x() * w_max.y() - u_max.y() * w_max.x();
+        const double perp_vw_min = v.x() * w_min.y() - v.y() * w_min.x();
+        const double perp_vw_max = v.x() * w_max.y() - v.y() * w_max.x();
+        const GenHitParameters params = generalizedPlaneHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
+                                                            perp_uw_max,
+                                                            perp_vw_min, perp_vw_max, p, v, t, t_end,
+                                                            ray.direction().y(),
+                                                            grid.sphereCenter().y(), grid.pMaxAngular(),
+                                                            current_voxel_ID_theta);
+        return {.tMaxTheta=params.tMax, .tStepTheta=params.tStep, .within_bounds=params.within_bounds};
+    }
 
 // Determines whether an azimuthal hit occurs for the given ray. An azimuthal hit is considered an intersection with
 // the ray and an azimuthal section. The azimuthal sections live in the XZ plane.
-AzimuthalHitParameters azimuthalHit(const Ray &ray, const SphericalVoxelGrid &grid,
-                                    int current_voxel_ID_phi, double t, double t_end) noexcept {
-    // Ray segment vector.
-    const BoundVec3 p = ray.pointAtParameter(t);
-    const BoundVec3 p_end = ray.pointAtParameter(t_end);
-    const FreeVec3 v = p_end - p;
-    // Calculate the voxel boundary vectors.
-    const FreeVec3 p_one(grid.pMaxAzimuthal(current_voxel_ID_phi).P1, 0.0,
-                         grid.pMaxAzimuthal(current_voxel_ID_phi).P2);
-    const FreeVec3 p_two(grid.pMaxAzimuthal(current_voxel_ID_phi+1).P1, 0.0,
-                         grid.pMaxAzimuthal(current_voxel_ID_phi+1).P2);
-    const BoundVec3 u_min = grid.sphereCenter() - p_one;
-    const BoundVec3 u_max = grid.sphereCenter() - p_two;
-    const FreeVec3 w_min = p_one - FreeVec3(p);
-    const FreeVec3 w_max = p_two - FreeVec3(p);
-    const double perp_uv_min = u_min.x() * v.z() - u_min.z() * v.x();
-    const double perp_uv_max = u_max.x() * v.z() - u_max.z() * v.x();
-    const double perp_uw_min = u_min.x() * w_min.z() - u_min.z() * w_min.x();
-    const double perp_uw_max = u_max.x() * w_max.z() - u_max.z() * w_max.x();
-    const double perp_vw_min = v.x() * w_min.z() - v.z() * w_min.x();
-    const double perp_vw_max = v.x() * w_max.z() - v.z() * w_max.x();
-    const GenHitParameters params = generalizedPlaneHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min, perp_uw_max,
-                                                        perp_vw_min, perp_vw_max, p, v, t, t_end, ray.direction().z(),
-                                                        grid.sphereCenter().z(), grid.pMaxAzimuthal(), current_voxel_ID_phi);
-    return {.tMaxPhi=params.tMax, .tStepPhi=params.tStep, .within_bounds=params.within_bounds};
-}
+    AzimuthalHitParameters azimuthalHit(const Ray &ray, const SVR::SphericalVoxelGrid &grid,
+                                        int current_voxel_ID_phi, double t, double t_end) noexcept {
+        // Ray segment vector.
+        const BoundVec3 p = ray.pointAtParameter(t);
+        const BoundVec3 p_end = ray.pointAtParameter(t_end);
+        const FreeVec3 v = p_end - p;
+        // Calculate the voxel boundary vectors.
+        const FreeVec3 p_one(grid.pMaxAzimuthal(current_voxel_ID_phi).P1, 0.0,
+                             grid.pMaxAzimuthal(current_voxel_ID_phi).P2);
+        const FreeVec3 p_two(grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P1, 0.0,
+                             grid.pMaxAzimuthal(current_voxel_ID_phi + 1).P2);
+        const BoundVec3 u_min = grid.sphereCenter() - p_one;
+        const BoundVec3 u_max = grid.sphereCenter() - p_two;
+        const FreeVec3 w_min = p_one - FreeVec3(p);
+        const FreeVec3 w_max = p_two - FreeVec3(p);
+        const double perp_uv_min = u_min.x() * v.z() - u_min.z() * v.x();
+        const double perp_uv_max = u_max.x() * v.z() - u_max.z() * v.x();
+        const double perp_uw_min = u_min.x() * w_min.z() - u_min.z() * w_min.x();
+        const double perp_uw_max = u_max.x() * w_max.z() - u_max.z() * w_max.x();
+        const double perp_vw_min = v.x() * w_min.z() - v.z() * w_min.x();
+        const double perp_vw_max = v.x() * w_max.z() - v.z() * w_max.x();
+        const GenHitParameters params = generalizedPlaneHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
+                                                            perp_uw_max,
+                                                            perp_vw_min, perp_vw_max, p, v, t, t_end,
+                                                            ray.direction().z(),
+                                                            grid.sphereCenter().z(), grid.pMaxAzimuthal(),
+                                                            current_voxel_ID_phi);
+        return {.tMaxPhi=params.tMax, .tStepPhi=params.tStep, .within_bounds=params.within_bounds};
+    }
 
 // Calculates the voxel(s) with the minimal tMax for the next intersection. Since t is being updated
 // with each interval of the algorithm, this must check the following cases:
@@ -395,231 +407,248 @@ AzimuthalHitParameters azimuthalHit(const Ray &ray, const SphericalVoxelGrid &gr
 // the ray intersects a single shell, but still crosses an angular or azimuthal boundary:
 // (1) tMax must be within bounds
 // (2) Either tMax is a strict minimum OR the next step is a radial exit.
-inline VoxelIntersectionType minimumIntersection(const RadialHitParameters &rad_params,
-                                                 const AngularHitParameters &ang_params,
-                                                 const AzimuthalHitParameters &azi_params) noexcept {
-    if (rad_params.within_bounds && rad_params.tMaxR < ang_params.tMaxTheta && rad_params.tMaxR < azi_params.tMaxPhi) {
-        return VoxelIntersectionType::Radial;
+    inline VoxelIntersectionType minimumIntersection(const RadialHitParameters &rad_params,
+                                                     const AngularHitParameters &ang_params,
+                                                     const AzimuthalHitParameters &azi_params) noexcept {
+        if (rad_params.within_bounds && rad_params.tMaxR < ang_params.tMaxTheta &&
+            rad_params.tMaxR < azi_params.tMaxPhi) {
+            return VoxelIntersectionType::Radial;
+        }
+        if (ang_params.within_bounds && ((ang_params.tMaxTheta < rad_params.tMaxR
+                                          && rad_params.tMaxR < azi_params.tMaxPhi) || rad_params.exits_voxel_bounds)) {
+            return VoxelIntersectionType::Angular;
+        }
+        if (azi_params.within_bounds && ((azi_params.tMaxPhi < ang_params.tMaxTheta
+                                          && azi_params.tMaxPhi < rad_params.tMaxR) || rad_params.exits_voxel_bounds)) {
+            return VoxelIntersectionType::Azimuthal;
+        }
+        if (rad_params.within_bounds && isKnEqual(rad_params.tMaxR, ang_params.tMaxTheta)
+            && isKnEqual(rad_params.tMaxR, azi_params.tMaxPhi)) {
+            return VoxelIntersectionType::RadialAngularAzimuthal;
+        }
+        if (azi_params.within_bounds && isKnEqual(azi_params.tMaxPhi, ang_params.tMaxTheta)) {
+            return VoxelIntersectionType::AngularAzimuthal;
+        }
+        if (rad_params.within_bounds && isKnEqual(ang_params.tMaxTheta, rad_params.tMaxR)) {
+            return VoxelIntersectionType::RadialAngular;
+        }
+        if (rad_params.within_bounds && isKnEqual(rad_params.tMaxR, azi_params.tMaxPhi)) {
+            return VoxelIntersectionType::RadialAzimuthal;
+        }
+        return VoxelIntersectionType::None;
     }
-    if (ang_params.within_bounds && ((ang_params.tMaxTheta < rad_params.tMaxR
-                                      && rad_params.tMaxR < azi_params.tMaxPhi) || rad_params.exits_voxel_bounds)) {
-        return VoxelIntersectionType::Angular;
-    }
-    if (azi_params.within_bounds && ((azi_params.tMaxPhi < ang_params.tMaxTheta
-                                      && azi_params.tMaxPhi < rad_params.tMaxR) || rad_params.exits_voxel_bounds)) {
-        return VoxelIntersectionType::Azimuthal;
-    }
-    if (rad_params.within_bounds && isKnEqual(rad_params.tMaxR, ang_params.tMaxTheta)
-        && isKnEqual(rad_params.tMaxR, azi_params.tMaxPhi)) {
-        return VoxelIntersectionType::RadialAngularAzimuthal;
-    }
-    if (azi_params.within_bounds && isKnEqual(azi_params.tMaxPhi, ang_params.tMaxTheta)) {
-        return VoxelIntersectionType::AngularAzimuthal;
-    }
-    if (rad_params.within_bounds && isKnEqual(ang_params.tMaxTheta, rad_params.tMaxR)) {
-        return VoxelIntersectionType::RadialAngular;
-    }
-    if (rad_params.within_bounds && isKnEqual(rad_params.tMaxR, azi_params.tMaxPhi)) {
-        return VoxelIntersectionType::RadialAzimuthal;
-    }
-    return VoxelIntersectionType::None;
-}
 
 // Create an array of values representing the points of intersection between the lines corresponding
 // to voxel boundaries and a given radial voxel in the XY plane and XZ plane. Here, P_* represents
 // these points with a given radius 'current_radius'. The case where the number of angular voxels is
 // equal to the number of azimuthal voxels is also checked to reduce the number of trigonometric
 // and floating point calculations.
-inline void initializeVoxelBoundarySegments(std::vector<LineSegment> &P_angular,
-                                            std::vector<LineSegment> &P_azimuthal,
-                                            const SphericalVoxelGrid &grid, double current_radius) noexcept {
-    double radians = 0;
-    if (grid.numAngularVoxels() == grid.numAzimuthalVoxels()) {
-        for (std::size_t i = 0; i < P_angular.size(); ++i) {
-            const double px_value = current_radius * std::cos(radians) + grid.sphereCenter().x();
-            const double current_radius_times_sin = current_radius * std::sin(radians);
-            P_angular[i].P1 = px_value;
-            P_angular[i].P2 = current_radius_times_sin + grid.sphereCenter().y();
-            P_azimuthal[i].P1 = px_value;
-            P_azimuthal[i].P2 = current_radius_times_sin + grid.sphereCenter().z();
+    inline void initializeVoxelBoundarySegments(std::vector<SVR::LineSegment> &P_angular,
+                                                std::vector<SVR::LineSegment> &P_azimuthal,
+                                                const SVR::SphericalVoxelGrid &grid, double current_radius) noexcept {
+        double radians = 0;
+        if (grid.numAngularVoxels() == grid.numAzimuthalVoxels()) {
+            for (std::size_t i = 0; i < P_angular.size(); ++i) {
+                const double px_value = current_radius * std::cos(radians) + grid.sphereCenter().x();
+                const double current_radius_times_sin = current_radius * std::sin(radians);
+                P_angular[i].P1 = px_value;
+                P_angular[i].P2 = current_radius_times_sin + grid.sphereCenter().y();
+                P_azimuthal[i].P1 = px_value;
+                P_azimuthal[i].P2 = current_radius_times_sin + grid.sphereCenter().z();
+                radians += grid.deltaTheta();
+            }
+            return;
+        }
+        for (std::size_t j = 0; j < P_angular.size(); ++j) {
+            P_angular[j].P1 = current_radius * std::cos(radians) + grid.sphereCenter().x();
+            P_angular[j].P2 = current_radius * std::sin(radians) + grid.sphereCenter().y();
             radians += grid.deltaTheta();
         }
-        return;
-    }
-    for (std::size_t j = 0; j < P_angular.size(); ++j) {
-        P_angular[j].P1 = current_radius * std::cos(radians) + grid.sphereCenter().x();
-        P_angular[j].P2 = current_radius * std::sin(radians) + grid.sphereCenter().y();
-        radians += grid.deltaTheta();
-    }
-    radians = 0;
-    for (std::size_t k = 0; k < P_azimuthal.size(); ++k) {
-        P_azimuthal[k].P1 = current_radius * std::cos(radians) + grid.sphereCenter().x();
-        P_azimuthal[k].P2 = current_radius * std::sin(radians) + grid.sphereCenter().z();
-        radians += grid.deltaPhi();
-    }
-}
-
-std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid,
-                                                              double t_begin, double t_end) noexcept {
-    // Determine ray location at t_begin.
-    const BoundVec3 point_at_t_begin = ray.pointAtParameter(t_begin);
-    const FreeVec3 ray_sphere_vector = grid.sphereCenter() - point_at_t_begin;
-    double entry_radius = grid.deltaRadius(); // The radius at which the ray first enters the sphere.
-
-    const double ray_sphere_vector_dot = ray_sphere_vector.dot(ray_sphere_vector);
-    while (ray_sphere_vector_dot > (entry_radius * entry_radius) && entry_radius < grid.sphereMaxRadius()) {
-        entry_radius += grid.deltaRadius();
-    }
-
-    // Find the intersection times for the ray and the radial shell containing the parameter point at t_begin.
-    // This will determine if the ray intersects the sphere.
-    const double v = ray_sphere_vector.dot(ray.unitDirection().to_free());
-    const double discriminant = (entry_radius * entry_radius) - (ray_sphere_vector_dot - v * v);
-
-    if (discriminant <= 0.0) { return {}; }
-    const double d = std::sqrt(discriminant);
-
-    // Calculate the time of entrance and exit of the ray.
-    // Need to use a non-zero direction to determine this.
-    const double t_begin_t1 = ray.timeOfIntersectionAt(v - d);
-    const double t_begin_t2 = ray.timeOfIntersectionAt(v + d);
-
-    if ((t_begin_t1 < t_begin && t_begin_t2 < t_begin) || isKnEqual(t_begin_t1, t_begin_t2)) {
-        // Case 1: No intersection.
-        // Case 2: Tangent hit.
-        return {};
-    }
-    int current_voxel_ID_r = 1 + (grid.sphereMaxRadius() - entry_radius) * grid.invDeltaRadius();
-    std::vector<LineSegment> P_angular(grid.numAngularVoxels() + 1);
-    std::vector<LineSegment> P_azimuthal(grid.numAzimuthalVoxels() + 1);
-    initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius);
-
-    double a, b, c;
-    const bool ray_origin_is_outside_grid = isKnEqual(entry_radius, grid.sphereMaxRadius());
-    if (isKnEqual(ray.origin(), grid.sphereCenter())) {
-        // If the ray starts at the sphere's center, we need to perturb slightly along
-        // the path to determine the correct angular and azimuthal voxel.
-        const double perturbed_t = 0.1;
-        a = grid.sphereCenter().x() - (point_at_t_begin.x() + ray.direction().x() * perturbed_t);
-        b = grid.sphereCenter().y() - (point_at_t_begin.y() + ray.direction().y() * perturbed_t);
-        c = grid.sphereCenter().z() - (point_at_t_begin.z() + ray.direction().z() * perturbed_t);
-    } else if (ray_origin_is_outside_grid) {
-        const BoundVec3 pa = ray.pointAtParameter(t_begin_t1);
-        a = grid.sphereCenter().x() - pa.x();
-        b = grid.sphereCenter().y() - pa.y();
-        c = grid.sphereCenter().z() - pa.z();
-    } else {
-        a = grid.sphereCenter().x() - ray.origin().x();
-        b = grid.sphereCenter().y() - ray.origin().y();
-        c = grid.sphereCenter().z() - ray.origin().z();
-    }
-
-    double p_x, p_y, p_z;
-    const double ang_plane_length = std::sqrt(a * a + b * b);
-    if (isKnEqual(ang_plane_length, 0.0)) {
-        p_x = grid.sphereCenter().x() + entry_radius;
-        p_y = grid.sphereCenter().y();
-    } else {
-        const double r_over_ang_plane_length = entry_radius / ang_plane_length;
-        p_x = grid.sphereCenter().x() - a * r_over_ang_plane_length;
-        p_y = grid.sphereCenter().y() - b * r_over_ang_plane_length;
-    }
-    int current_voxel_ID_theta = calculateVoxelID(P_angular, p_x, p_y);
-
-    const double azi_plane_length = std::sqrt(a * a + c * c);
-    if (isKnEqual(azi_plane_length, 0.0)) {
-        p_x = grid.sphereCenter().x() + entry_radius;
-        p_z = grid.sphereCenter().z();
-    } else {
-        const double r_over_azi_plane_length = entry_radius / azi_plane_length;
-        p_x = grid.sphereCenter().x() - a * r_over_azi_plane_length;
-        p_z = grid.sphereCenter().z() - c * r_over_azi_plane_length;
-    }
-    int current_voxel_ID_phi = calculateVoxelID(P_azimuthal, p_x, p_z);
-
-    std::vector<SphericalVoxel> voxels;
-    voxels.reserve(grid.numRadialVoxels() + grid.numAngularVoxels() + grid.numAzimuthalVoxels());
-    voxels.push_back({.radial_voxel=current_voxel_ID_r,
-                      .angular_voxel=current_voxel_ID_theta,
-                      .azimuthal_voxel=current_voxel_ID_phi});
-
-    // Find the maximum time the ray will be in the grid.
-    const double max_discriminant = grid.sphereMaxRadius() * grid.sphereMaxRadius() - (ray_sphere_vector_dot - v * v);
-    const double max_d = std::sqrt(max_discriminant);
-    const double t_grid_exit = MAX(ray.timeOfIntersectionAt(v - max_d), ray.timeOfIntersectionAt(v + max_d));
-    // Find the correct time to begin the traversal phase.
-    double t = ray_origin_is_outside_grid ? ray.timeOfIntersectionAt(Vec3(p_x, p_y, p_z)) : t_begin;
-    t_end = MIN(t_grid_exit, t_end);
-
-    RadialHitData radial_hit_data(v, ray_sphere_vector_dot);
-    while (true) {
-        const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
-        radial_hit_data.previous_transition_flag = radial_params.previous_transition_flag;
-        const auto angular_params = angularHit(ray, grid, current_voxel_ID_theta, t, t_end);
-        const auto azimuthal_params = azimuthalHit(ray, grid, current_voxel_ID_phi, t, t_end);
-        const auto voxel_intersection = minimumIntersection(radial_params, angular_params, azimuthal_params);
-        switch (voxel_intersection) {
-            case Radial: {
-                t = radial_params.tMaxR;
-                current_voxel_ID_r += radial_params.tStepR;
-                break;
-            }
-            case Angular: {
-                t = angular_params.tMaxTheta;
-                current_voxel_ID_theta = (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
-                break;
-            }
-            case Azimuthal: {
-                t = azimuthal_params.tMaxPhi;
-                current_voxel_ID_phi = (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
-                break;
-            }
-            case RadialAngular: {
-                t = radial_params.tMaxR;
-                current_voxel_ID_r += radial_params.tStepR;
-                current_voxel_ID_theta = (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
-                break;
-            }
-            case RadialAzimuthal: {
-                t = radial_params.tMaxR;
-                current_voxel_ID_r += radial_params.tStepR;
-                current_voxel_ID_phi = (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
-                break;
-            }
-            case AngularAzimuthal: {
-                t = angular_params.tMaxTheta;
-                current_voxel_ID_theta = (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
-                current_voxel_ID_phi = (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
-                break;
-            }
-            case RadialAngularAzimuthal: {
-                t = radial_params.tMaxR;
-                current_voxel_ID_r += radial_params.tStepR;
-                current_voxel_ID_theta = (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
-                current_voxel_ID_phi = (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
-                break;
-            }
-            case None: { return voxels; }
+        radians = 0;
+        for (std::size_t k = 0; k < P_azimuthal.size(); ++k) {
+            P_azimuthal[k].P1 = current_radius * std::cos(radians) + grid.sphereCenter().x();
+            P_azimuthal[k].P2 = current_radius * std::sin(radians) + grid.sphereCenter().z();
+            radians += grid.deltaPhi();
         }
-        voxels.push_back({.radial_voxel=current_voxel_ID_r,
-                          .angular_voxel=current_voxel_ID_theta,
-                          .azimuthal_voxel=current_voxel_ID_phi});
     }
-    return voxels;
-}
 
-std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,
-                                                                double *min_bound, double *max_bound,
-                                                                std::size_t num_radial_voxels,
-                                                                std::size_t num_angular_voxels,
-                                                                std::size_t num_azimuthal_voxels, double *sphere_center,
-                                                                double sphere_max_radius, double t_begin,
-                                                                double t_end) noexcept {
-    const Ray ray(BoundVec3(ray_origin[0], ray_origin[1], ray_origin[2]),
-                  FreeVec3(ray_direction[0], ray_direction[1], ray_direction[2]));
-    const SphericalVoxelGrid grid(BoundVec3(min_bound[0], min_bound[1], min_bound[2]),
-                                  BoundVec3(max_bound[0], max_bound[1], max_bound[2]),
-                                  num_radial_voxels, num_angular_voxels, num_azimuthal_voxels,
-                                  BoundVec3(sphere_center[0], sphere_center[1], sphere_center[2]), sphere_max_radius);
-    return sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-}
+    std::vector<SVR::SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray,
+                                                                       const SVR::SphericalVoxelGrid &grid,
+                                                                       double t_begin, double t_end) noexcept {
+        // Determine ray location at t_begin.
+        const BoundVec3 point_at_t_begin = ray.pointAtParameter(t_begin);
+        const FreeVec3 ray_sphere_vector = grid.sphereCenter() - point_at_t_begin;
+        double entry_radius = grid.deltaRadius(); // The radius at which the ray first enters the sphere.
+
+        const double ray_sphere_vector_dot = ray_sphere_vector.dot(ray_sphere_vector);
+        while (ray_sphere_vector_dot > (entry_radius * entry_radius) && entry_radius < grid.sphereMaxRadius()) {
+            entry_radius += grid.deltaRadius();
+        }
+
+        // Find the intersection times for the ray and the radial shell containing the parameter point at t_begin.
+        // This will determine if the ray intersects the sphere.
+        const double v = ray_sphere_vector.dot(ray.unitDirection().to_free());
+        const double discriminant = (entry_radius * entry_radius) - (ray_sphere_vector_dot - v * v);
+
+        if (discriminant <= 0.0) { return {}; }
+        const double d = std::sqrt(discriminant);
+
+        // Calculate the time of entrance and exit of the ray.
+        // Need to use a non-zero direction to determine this.
+        const double t_begin_t1 = ray.timeOfIntersectionAt(v - d);
+        const double t_begin_t2 = ray.timeOfIntersectionAt(v + d);
+
+        if ((t_begin_t1 < t_begin && t_begin_t2 < t_begin) || isKnEqual(t_begin_t1, t_begin_t2)) {
+            // Case 1: No intersection.
+            // Case 2: Tangent hit.
+            return {};
+        }
+        int current_voxel_ID_r = 1 + (grid.sphereMaxRadius() - entry_radius) * grid.invDeltaRadius();
+        std::vector<SVR::LineSegment> P_angular(grid.numAngularVoxels() + 1);
+        std::vector<SVR::LineSegment> P_azimuthal(grid.numAzimuthalVoxels() + 1);
+        initializeVoxelBoundarySegments(P_angular, P_azimuthal, grid, entry_radius);
+
+        double a, b, c;
+        const bool ray_origin_is_outside_grid = isKnEqual(entry_radius, grid.sphereMaxRadius());
+        if (isKnEqual(ray.origin(), grid.sphereCenter())) {
+            // If the ray starts at the sphere's center, we need to perturb slightly along
+            // the path to determine the correct angular and azimuthal voxel.
+            const double perturbed_t = 0.1;
+            a = grid.sphereCenter().x() - (point_at_t_begin.x() + ray.direction().x() * perturbed_t);
+            b = grid.sphereCenter().y() - (point_at_t_begin.y() + ray.direction().y() * perturbed_t);
+            c = grid.sphereCenter().z() - (point_at_t_begin.z() + ray.direction().z() * perturbed_t);
+        } else if (ray_origin_is_outside_grid) {
+            const BoundVec3 pa = ray.pointAtParameter(t_begin_t1);
+            a = grid.sphereCenter().x() - pa.x();
+            b = grid.sphereCenter().y() - pa.y();
+            c = grid.sphereCenter().z() - pa.z();
+        } else {
+            a = grid.sphereCenter().x() - ray.origin().x();
+            b = grid.sphereCenter().y() - ray.origin().y();
+            c = grid.sphereCenter().z() - ray.origin().z();
+        }
+
+        double p_x, p_y, p_z;
+        const double ang_plane_length = std::sqrt(a * a + b * b);
+        if (isKnEqual(ang_plane_length, 0.0)) {
+            p_x = grid.sphereCenter().x() + entry_radius;
+            p_y = grid.sphereCenter().y();
+        } else {
+            const double r_over_ang_plane_length = entry_radius / ang_plane_length;
+            p_x = grid.sphereCenter().x() - a * r_over_ang_plane_length;
+            p_y = grid.sphereCenter().y() - b * r_over_ang_plane_length;
+        }
+        int current_voxel_ID_theta = calculateVoxelID(P_angular, p_x, p_y);
+
+        const double azi_plane_length = std::sqrt(a * a + c * c);
+        if (isKnEqual(azi_plane_length, 0.0)) {
+            p_x = grid.sphereCenter().x() + entry_radius;
+            p_z = grid.sphereCenter().z();
+        } else {
+            const double r_over_azi_plane_length = entry_radius / azi_plane_length;
+            p_x = grid.sphereCenter().x() - a * r_over_azi_plane_length;
+            p_z = grid.sphereCenter().z() - c * r_over_azi_plane_length;
+        }
+        int current_voxel_ID_phi = calculateVoxelID(P_azimuthal, p_x, p_z);
+
+        std::vector<SVR::SphericalVoxel> voxels;
+        voxels.reserve(grid.numRadialVoxels() + grid.numAngularVoxels() + grid.numAzimuthalVoxels());
+        voxels.push_back({.radial_voxel=current_voxel_ID_r,
+                                 .angular_voxel=current_voxel_ID_theta,
+                                 .azimuthal_voxel=current_voxel_ID_phi});
+
+        // Find the maximum time the ray will be in the grid.
+        const double max_discriminant =
+                grid.sphereMaxRadius() * grid.sphereMaxRadius() - (ray_sphere_vector_dot - v * v);
+        const double max_d = std::sqrt(max_discriminant);
+        const double t_grid_exit = MAX(ray.timeOfIntersectionAt(v - max_d), ray.timeOfIntersectionAt(v + max_d));
+        // Find the correct time to begin the traversal phase.
+        double t = ray_origin_is_outside_grid ? ray.timeOfIntersectionAt(Vec3(p_x, p_y, p_z)) : t_begin;
+        t_end = MIN(t_grid_exit, t_end);
+
+        RadialHitData radial_hit_data(v, ray_sphere_vector_dot);
+        while (true) {
+            const auto radial_params = radialHit(ray, grid, radial_hit_data, current_voxel_ID_r, t, t_end);
+            radial_hit_data.previous_transition_flag = radial_params.previous_transition_flag;
+            const auto angular_params = angularHit(ray, grid, current_voxel_ID_theta, t, t_end);
+            const auto azimuthal_params = azimuthalHit(ray, grid, current_voxel_ID_phi, t, t_end);
+            const auto voxel_intersection = minimumIntersection(radial_params, angular_params, azimuthal_params);
+            switch (voxel_intersection) {
+                case Radial: {
+                    t = radial_params.tMaxR;
+                    current_voxel_ID_r += radial_params.tStepR;
+                    break;
+                }
+                case Angular: {
+                    t = angular_params.tMaxTheta;
+                    current_voxel_ID_theta =
+                            (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
+                    break;
+                }
+                case Azimuthal: {
+                    t = azimuthal_params.tMaxPhi;
+                    current_voxel_ID_phi =
+                            (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
+                    break;
+                }
+                case RadialAngular: {
+                    t = radial_params.tMaxR;
+                    current_voxel_ID_r += radial_params.tStepR;
+                    current_voxel_ID_theta =
+                            (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
+                    break;
+                }
+                case RadialAzimuthal: {
+                    t = radial_params.tMaxR;
+                    current_voxel_ID_r += radial_params.tStepR;
+                    current_voxel_ID_phi =
+                            (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
+                    break;
+                }
+                case AngularAzimuthal: {
+                    t = angular_params.tMaxTheta;
+                    current_voxel_ID_theta =
+                            (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
+                    current_voxel_ID_phi =
+                            (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
+                    break;
+                }
+                case RadialAngularAzimuthal: {
+                    t = radial_params.tMaxR;
+                    current_voxel_ID_r += radial_params.tStepR;
+                    current_voxel_ID_theta =
+                            (current_voxel_ID_theta + angular_params.tStepTheta) % grid.numAngularVoxels();
+                    current_voxel_ID_phi =
+                            (current_voxel_ID_phi + azimuthal_params.tStepPhi) % grid.numAzimuthalVoxels();
+                    break;
+                }
+                case None: {
+                    return voxels;
+                }
+            }
+            voxels.push_back({.radial_voxel=current_voxel_ID_r,
+                                     .angular_voxel=current_voxel_ID_theta,
+                                     .azimuthal_voxel=current_voxel_ID_phi});
+        }
+        return voxels;
+    }
+
+    std::vector<SVR::SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,
+                                                                         double *min_bound, double *max_bound,
+                                                                         std::size_t num_radial_voxels,
+                                                                         std::size_t num_angular_voxels,
+                                                                         std::size_t num_azimuthal_voxels,
+                                                                         double *sphere_center,
+                                                                         double sphere_max_radius, double t_begin,
+                                                                         double t_end) noexcept {
+        const Ray ray(BoundVec3(ray_origin[0], ray_origin[1], ray_origin[2]),
+                      FreeVec3(ray_direction[0], ray_direction[1], ray_direction[2]));
+        const SVR::SphericalVoxelGrid grid(BoundVec3(min_bound[0], min_bound[1], min_bound[2]),
+                                           BoundVec3(max_bound[0], max_bound[1], max_bound[2]),
+                                           num_radial_voxels, num_angular_voxels, num_azimuthal_voxels,
+                                           BoundVec3(sphere_center[0], sphere_center[1], sphere_center[2]),
+                                           sphere_max_radius);
+        return SVR::sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+    }
+
+} // namespace SVR

--- a/cpp/spherical_volume_rendering_util.h
+++ b/cpp/spherical_volume_rendering_util.h
@@ -6,12 +6,14 @@
 #include "spherical_voxel_grid.h"
 #include <vector>
 
+namespace SVR {
+
 // Represents a spherical voxel coordinate.
-struct SphericalVoxel {
-    int radial_voxel;
-    int angular_voxel;
-    int azimuthal_voxel;
-};
+    struct SphericalVoxel {
+        int radial_voxel;
+        int angular_voxel;
+        int azimuthal_voxel;
+    };
 
 // A spherical coordinate voxel traversal algorithm. The algorithm traces the ray over the spherical voxel grid
 // provided. t_begin is the time the ray begins, and t_end is the time at which the ray ends. Returns a vector of the
@@ -20,16 +22,19 @@ struct SphericalVoxel {
 //
 // Notes: For further documentation and visualization, see the Progress Report for the algorithm:
 // https://docs.google.com/document/d/1ixD7XNu39kwwXhvQooMNb79x18-GsyMPLodzvwC3X-E/edit?usp=sharing
-std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, const SphericalVoxelGrid &grid,
-                                                              double t_begin, double t_end) noexcept;
+    std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversal(const Ray &ray, const SVR::SphericalVoxelGrid &grid,
+                                                                  double t_begin, double t_end) noexcept;
 
 // Simplified parameters to Cythonize the function; implementation remains the same as above.
-std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,
-                                                                double *min_bound, double *max_bound,
-                                                                std::size_t num_radial_voxels,
-                                                                std::size_t num_angular_voxels,
-                                                                std::size_t num_azimuthal_voxels, double *sphere_center,
-                                                                double sphere_max_radius, double t_begin,
-                                                                double t_end) noexcept;
+    std::vector<SphericalVoxel> sphericalCoordinateVoxelTraversalCy(double *ray_origin, double *ray_direction,
+                                                                    double *min_bound, double *max_bound,
+                                                                    std::size_t num_radial_voxels,
+                                                                    std::size_t num_angular_voxels,
+                                                                    std::size_t num_azimuthal_voxels,
+                                                                    double *sphere_center,
+                                                                    double sphere_max_radius, double t_begin,
+                                                                    double t_end) noexcept;
+
+} // namespace SVR
 
 #endif //SPHERICAL_VOLUME_RENDERING_SPHERICALVOLUMERENDERINGUTIL_H

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -4,12 +4,14 @@
 #include "vec3.h"
 #include <vector>
 
+namespace SVR {
+
 // Represents a line segment. This is used to represent the points of intersections between
 // the lines corresponding to voxel boundaries and a given radial voxel.
-struct LineSegment {
-    double P1;
-    double P2;
-};
+    struct LineSegment {
+        double P1;
+        double P2;
+    };
 
 // Represents a 3-dimensional spherical voxel grid. The minimum and maximum bounds [min_bound_, max_bound_]
 // contain the entirety of the sphere that is to be traversed.
@@ -19,130 +21,133 @@ struct LineSegment {
 //   num_angular_voxels > 0
 //   num_azimuthal_voxels > 0
 //   sphere_max_radius > 0.0
-struct SphericalVoxelGrid {
-public:
-    SphericalVoxelGrid(const BoundVec3 &min_bound, const BoundVec3 &max_bound, std::size_t num_radial_voxels,
-                       std::size_t num_angular_voxels, std::size_t num_azimuthal_voxels, const BoundVec3 &sphere_center,
-                       double sphere_max_radius) :
-            min_bound_(min_bound),
-            max_bound_(max_bound),
-            num_radial_voxels_(num_radial_voxels),
-            num_angular_voxels_(num_angular_voxels),
-            num_azimuthal_voxels_(num_azimuthal_voxels),
-            inv_num_radial_voxels_(1.0 / num_radial_voxels),
-            inv_num_angular_voxels_(1.0 / num_angular_voxels),
-            inv_num_azimuthal_voxels_(1.0 / num_azimuthal_voxels),
-            sphere_center_(sphere_center),
-            sphere_max_radius_(sphere_max_radius),
-            delta_radius_(sphere_max_radius * inv_num_radial_voxels_),
-            delta_theta_(2 * M_PI * inv_num_angular_voxels_),
-            delta_phi_(2 * M_PI * inv_num_azimuthal_voxels_),
-            inv_delta_radius_(1.0 / delta_radius_),
-            inv_delta_theta_(1.0 / delta_theta_),
-            inv_delta_phi_(1.0 / delta_phi_) {
+    struct SphericalVoxelGrid {
+    public:
+        SphericalVoxelGrid(const BoundVec3 &min_bound, const BoundVec3 &max_bound, std::size_t num_radial_voxels,
+                           std::size_t num_angular_voxels, std::size_t num_azimuthal_voxels,
+                           const BoundVec3 &sphere_center,
+                           double sphere_max_radius) :
+                min_bound_(min_bound),
+                max_bound_(max_bound),
+                num_radial_voxels_(num_radial_voxels),
+                num_angular_voxels_(num_angular_voxels),
+                num_azimuthal_voxels_(num_azimuthal_voxels),
+                inv_num_radial_voxels_(1.0 / num_radial_voxels),
+                inv_num_angular_voxels_(1.0 / num_angular_voxels),
+                inv_num_azimuthal_voxels_(1.0 / num_azimuthal_voxels),
+                sphere_center_(sphere_center),
+                sphere_max_radius_(sphere_max_radius),
+                delta_radius_(sphere_max_radius * inv_num_radial_voxels_),
+                delta_theta_(2 * M_PI * inv_num_angular_voxels_),
+                delta_phi_(2 * M_PI * inv_num_azimuthal_voxels_),
+                inv_delta_radius_(1.0 / delta_radius_),
+                inv_delta_theta_(1.0 / delta_theta_),
+                inv_delta_phi_(1.0 / delta_phi_) {
 
-        double radians = 0;
-        P_max_angular_.resize(num_angular_voxels + 1);
-        P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
+            double radians = 0;
+            P_max_angular_.resize(num_angular_voxels + 1);
+            P_max_azimuthal_.resize(num_azimuthal_voxels + 1);
 
-        if (num_angular_voxels == num_azimuthal_voxels) {
-            for (std::size_t i = 0; i < num_angular_voxels; ++i) {
-                const double px_max_value = sphere_max_radius * std::cos(radians) + sphere_center.x();
-                const double max_radius_times_s = sphere_max_radius * std::sin(radians);
-                P_max_angular_[i].P1 = px_max_value;
-                P_max_angular_[i].P2 = max_radius_times_s + sphere_center.y();
-                P_max_azimuthal_[i].P1 = px_max_value;
-                P_max_azimuthal_[i].P2 = max_radius_times_s + sphere_center.z();
+            if (num_angular_voxels == num_azimuthal_voxels) {
+                for (std::size_t i = 0; i < num_angular_voxels; ++i) {
+                    const double px_max_value = sphere_max_radius * std::cos(radians) + sphere_center.x();
+                    const double max_radius_times_s = sphere_max_radius * std::sin(radians);
+                    P_max_angular_[i].P1 = px_max_value;
+                    P_max_angular_[i].P2 = max_radius_times_s + sphere_center.y();
+                    P_max_azimuthal_[i].P1 = px_max_value;
+                    P_max_azimuthal_[i].P2 = max_radius_times_s + sphere_center.z();
+                    radians += delta_phi_;
+                }
+                return;
+            }
+            for (std::size_t j = 0; j < num_angular_voxels; ++j) {
+                P_max_angular_[j].P1 = sphere_max_radius * std::cos(radians) + sphere_center.x();
+                P_max_angular_[j].P2 = sphere_max_radius * std::sin(radians) + sphere_center.y();
+                radians += delta_theta_;
+            }
+            radians = 0;
+            for (std::size_t k = 0; k < num_azimuthal_voxels; ++k) {
+                P_max_azimuthal_[k].P1 = sphere_max_radius * std::cos(radians) + sphere_center.x();
+                P_max_azimuthal_[k].P2 = sphere_max_radius * std::sin(radians) + sphere_center.z();
                 radians += delta_phi_;
             }
-            return;
         }
-        for (std::size_t j = 0; j < num_angular_voxels; ++j) {
-            P_max_angular_[j].P1 = sphere_max_radius * std::cos(radians) + sphere_center.x();
-            P_max_angular_[j].P2 = sphere_max_radius * std::sin(radians) + sphere_center.y();
-            radians += delta_theta_;
-        }
-        radians = 0;
-        for (std::size_t k = 0; k < num_azimuthal_voxels; ++k) {
-            P_max_azimuthal_[k].P1 = sphere_max_radius * std::cos(radians) + sphere_center.x();
-            P_max_azimuthal_[k].P2 = sphere_max_radius * std::sin(radians) + sphere_center.z();
-            radians += delta_phi_;
-        }
-    }
 
-    inline std::size_t numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
+        inline std::size_t numRadialVoxels() const noexcept { return this->num_radial_voxels_; }
 
-    inline std::size_t numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
+        inline std::size_t numAngularVoxels() const noexcept { return this->num_angular_voxels_; }
 
-    inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
+        inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
 
-    inline double invNumRadialVoxels() const noexcept { return this->inv_num_radial_voxels_; }
+        inline double invNumRadialVoxels() const noexcept { return this->inv_num_radial_voxels_; }
 
-    inline double invNumAngularVoxels() const noexcept { return this->inv_num_angular_voxels_; }
+        inline double invNumAngularVoxels() const noexcept { return this->inv_num_angular_voxels_; }
 
-    inline double invNumAzimuthalVoxels() const noexcept { return this->inv_num_azimuthal_voxels_; }
+        inline double invNumAzimuthalVoxels() const noexcept { return this->inv_num_azimuthal_voxels_; }
 
-    inline BoundVec3 minBound() const noexcept { return this->min_bound_; }
+        inline BoundVec3 minBound() const noexcept { return this->min_bound_; }
 
-    inline BoundVec3 maxBound() const noexcept { return this->max_bound_; }
+        inline BoundVec3 maxBound() const noexcept { return this->max_bound_; }
 
-    inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
+        inline double sphereMaxRadius() const noexcept { return this->sphere_max_radius_; }
 
-    inline BoundVec3 sphereCenter() const noexcept { return this->sphere_center_; }
+        inline BoundVec3 sphereCenter() const noexcept { return this->sphere_center_; }
 
-    inline double deltaRadius() const noexcept { return this->delta_radius_; }
+        inline double deltaRadius() const noexcept { return this->delta_radius_; }
 
-    inline double deltaTheta() const noexcept { return this->delta_theta_; }
+        inline double deltaTheta() const noexcept { return this->delta_theta_; }
 
-    inline double deltaPhi() const noexcept { return this->delta_phi_; }
+        inline double deltaPhi() const noexcept { return this->delta_phi_; }
 
-    inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
+        inline double invDeltaRadius() const noexcept { return this->inv_delta_radius_; }
 
-    inline double invDeltaTheta() const noexcept { return this->inv_delta_theta_; }
+        inline double invDeltaTheta() const noexcept { return this->inv_delta_theta_; }
 
-    inline double invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
+        inline double invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
 
-    inline const LineSegment& pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
+        inline const LineSegment &pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
-    inline const std::vector<LineSegment>& pMaxAngular() const noexcept { return this->P_max_angular_; }
+        inline const std::vector<LineSegment> &pMaxAngular() const noexcept { return this->P_max_angular_; }
 
-    inline const LineSegment& pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
+        inline const LineSegment &pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
 
-    inline const std::vector<LineSegment>& pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
+        inline const std::vector<LineSegment> &pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
 
-private:
-    // The minimum bound vector of the voxel grid.
-    const BoundVec3 min_bound_;
+    private:
+        // The minimum bound vector of the voxel grid.
+        const BoundVec3 min_bound_;
 
-    // The maximum bound vector of the voxel grid.
-    const BoundVec3 max_bound_;
+        // The maximum bound vector of the voxel grid.
+        const BoundVec3 max_bound_;
 
-    // The number of radial, angular, and azimuthal voxels.
-    const std::size_t num_radial_voxels_, num_angular_voxels_, num_azimuthal_voxels_;
+        // The number of radial, angular, and azimuthal voxels.
+        const std::size_t num_radial_voxels_, num_angular_voxels_, num_azimuthal_voxels_;
 
-    // Similar to num_x_voxels, but 1 / x, where x is the number of voxels.
-    const double inv_num_radial_voxels_, inv_num_angular_voxels_, inv_num_azimuthal_voxels_;
+        // Similar to num_x_voxels, but 1 / x, where x is the number of voxels.
+        const double inv_num_radial_voxels_, inv_num_angular_voxels_, inv_num_azimuthal_voxels_;
 
-    // The center of the sphere.
-    const BoundVec3 sphere_center_;
+        // The center of the sphere.
+        const BoundVec3 sphere_center_;
 
-    // The maximum radius of the sphere.
-    const double sphere_max_radius_;
+        // The maximum radius of the sphere.
+        const double sphere_max_radius_;
 
-    // The maximum sphere radius divided by the number of radial sections.
-    const double delta_radius_;
+        // The maximum sphere radius divided by the number of radial sections.
+        const double delta_radius_;
 
-    // 2 * PI divided by X, where X is the number of angular and number of azimuthal sections respectively.
-    const double delta_theta_, delta_phi_;
+        // 2 * PI divided by X, where X is the number of angular and number of azimuthal sections respectively.
+        const double delta_theta_, delta_phi_;
 
-    // Inverse of the above delta values.
-    const double inv_delta_radius_, inv_delta_theta_, inv_delta_phi_;
+        // Inverse of the above delta values.
+        const double inv_delta_radius_, inv_delta_theta_, inv_delta_phi_;
 
-    // The maximum radius line segments for angular voxels.
-    std::vector<LineSegment> P_max_angular_;
+        // The maximum radius line segments for angular voxels.
+        std::vector<LineSegment> P_max_angular_;
 
-    // The maximum radius line segments for azimuthal voxels.
-    std::vector<LineSegment> P_max_azimuthal_;
-};
+        // The maximum radius line segments for azimuthal voxels.
+        std::vector<LineSegment> P_max_azimuthal_;
+    };
+
+} // namespace SVR
 
 #endif //SPHERICAL_VOLUME_RENDERING_SPHERICALVOXELGRID_H

--- a/cpp/spherical_voxel_grid.h
+++ b/cpp/spherical_voxel_grid.h
@@ -76,7 +76,7 @@ public:
 
     inline std::size_t numAzimuthalVoxels() const noexcept { return this->num_azimuthal_voxels_; }
 
-    inline double invNumRadialVoxels() const noexcept{ return this->inv_num_radial_voxels_; }
+    inline double invNumRadialVoxels() const noexcept { return this->inv_num_radial_voxels_; }
 
     inline double invNumAngularVoxels() const noexcept { return this->inv_num_angular_voxels_; }
 
@@ -102,11 +102,11 @@ public:
 
     inline double invDeltaPhi() const noexcept { return this->inv_delta_phi_; }
 
-    inline const LineSegment& pMaxAngular(int i) const noexcept { return this->P_max_angular_[i]; }
+    inline const LineSegment& pMaxAngular(std::size_t i) const noexcept { return this->P_max_angular_[i]; }
 
     inline const std::vector<LineSegment>& pMaxAngular() const noexcept { return this->P_max_angular_; }
 
-    inline const LineSegment& pMaxAzimuthal(int i) const noexcept { return this->P_max_azimuthal_[i]; }
+    inline const LineSegment& pMaxAzimuthal(std::size_t i) const noexcept { return this->P_max_azimuthal_[i]; }
 
     inline const std::vector<LineSegment>& pMaxAzimuthal() const noexcept { return this->P_max_azimuthal_; }
 

--- a/cpp/testing/CMakeLists.txt
+++ b/cpp/testing/CMakeLists.txt
@@ -3,19 +3,19 @@ set(CMAKE_CXX_STANDARD 11)
 project(SVR)
 
 set(TESTING_BINARY ${CMAKE_PROJECT_NAME}_tests)
-set(BENCHMARK_BINARY ${CMAKE_PROJECT_NAME}_benchmark)
+set(BENCHMARK_BINARY ${CMAKE_PROJECT_NAME}_benchmarks)
 set(TESTING_SOURCE_FILES ../spherical_volume_rendering_util.cpp SVR_tests.cpp)
 set(BENCHMARK_SOURCE_FILES ../spherical_volume_rendering_util.cpp SVR_benchmarks.cpp)
 
 add_definitions(-DNDEBUG)
 add_subdirectory(googletest)
 add_subdirectory(benchmark)
-include_directories(${../cpp})
+
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(${gmock_SOURCE_DIR}/include ${gmock_SOURCE_DIR})
 
 add_executable(${BENCHMARK_BINARY} ${BENCHMARK_SOURCE_FILES})
 add_executable(${TESTING_BINARY} ${TESTING_SOURCE_FILES})
-add_test(NAME ${TESTING_BINARY} COMMAND ${TESTING_BINARY})
+
 target_link_libraries(${BENCHMARK_BINARY} benchmark::benchmark)
 target_link_libraries(${TESTING_BINARY} gtest gtest_main gmock gmock_main)

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -2,6 +2,8 @@
 #include "../spherical_volume_rendering_util.h"
 
 // Benchmarking for the Spherical Volume Rendering algorithm.
+// Uses the Google Benchmark library found at:
+// https://github.com/google/benchmark
 
 namespace {
     static void TraversalOne(benchmark::State &state) {

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -1,199 +1,205 @@
 #include <benchmark/benchmark.h>
 #include "../spherical_volume_rendering_util.h"
 
-static void TraversalOne(benchmark::State& state) {
-    for (auto _ : state) {
-        // Traversal from bottom left to upper right.
-        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10000.0;
-        const std::size_t num_radial_sections = 10000;
-        const std::size_t num_angular_sections = 10000;
-        const std::size_t num_azimuthal_sections = 10000;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                      num_angular_sections,
-                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(-13000.0, -13000.0, -13000.0);
-        const FreeVec3 ray_direction(1.0, 1.0, 1.0);
-        const Ray ray(ray_origin, ray_direction);
-        const double t_begin = 0.0;
-        const double t_end = 100000.0;
-        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-    }
-}
+// Benchmarking for the Spherical Volume Rendering algorithm.
 
-static void TraversalTwo(benchmark::State& state) {
-    for (auto _ : state) {
-        // Traversal from upper right to bottom left.
-        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10000.0;
-        const std::size_t num_radial_sections = 10000;
-        const std::size_t num_angular_sections = 10000;
-        const std::size_t num_azimuthal_sections = 10000;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                      num_angular_sections,
-                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const BoundVec3 ray_origin(13000.0, 13000.0, 13000.0);
-        const FreeVec3 ray_direction(-1.0, -1.0, -1.0);
-        const Ray ray(ray_origin, ray_direction);
-        const double t_begin = 0.0;
-        const double t_end = 100000.0;
-        const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-    }
-}
-
-static void TraversalParallelX(benchmark::State& state) {
-    for (auto _ : state) {
-        const BoundVec3 min_bound4(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound4(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center4(0.0, 0.0, 0.0);
-        const double sphere_max_radius4 = 10000.0;
-        const std::size_t num_radial_sections4 = 10000;
-        const std::size_t num_angular_sections4 = 10000;
-        const std::size_t num_azimuthal_sections4 = 10000;
-        const SphericalVoxelGrid grid4(min_bound4, max_bound4, num_radial_sections4,
-                                       num_angular_sections4,
-                                       num_azimuthal_sections4, sphere_center4, sphere_max_radius4);
-        const BoundVec3 ray_origin4(-13000.0, 10.0, 10.0);
-        const FreeVec3 ray_direction4(1.0, 0.0, 0.0);
-        const Ray ray4(ray_origin4, ray_direction4);
-        const double t_begin4 = 0.0;
-        const double t_end4 = 100000.0;
-        const auto actual_voxels4 = sphericalCoordinateVoxelTraversal(ray4, grid4, t_begin4, t_end4);
-    }
-}
-
-static void TraversalParallelY(benchmark::State& state) {
-    for (auto _ : state) {
-        const BoundVec3 min_bound2(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound2(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center2(0.0, 0.0, 0.0);
-        const double sphere_max_radius2 = 10000.0;
-        const std::size_t num_radial_sections2 = 10000;
-        const std::size_t num_angular_sections2 = 10000;
-        const std::size_t num_azimuthal_sections2 = 10000;
-        const SphericalVoxelGrid grid2(min_bound2, max_bound2, num_radial_sections2,
-                                       num_angular_sections2,
-                                       num_azimuthal_sections2, sphere_center2, sphere_max_radius2);
-        const BoundVec3 ray_origin2(10.0, -13000.0, 0.0);
-        const FreeVec3 ray_direction2(0.0, 1.0, 0.0);
-        const Ray ray2(ray_origin2, ray_direction2);
-        const double t_begin2 = 0.0;
-        const double t_end2 = 100000.0;
-        const auto actual_voxels2 = sphericalCoordinateVoxelTraversal(ray2, grid2, t_begin2, t_end2);
-}
-}
-
-static void TraversalParallelZ(benchmark::State& state) {
-    for (auto _ : state) {
-        const BoundVec3 min_bound3(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound3(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center3(0.0, 0.0, 0.0);
-        const double sphere_max_radius3 = 10000.0;
-        const std::size_t num_radial_sections3 = 10000;
-        const std::size_t num_angular_sections3 = 10000;
-        const std::size_t num_azimuthal_sections3 = 10000;
-        const SphericalVoxelGrid grid3(min_bound3, max_bound3, num_radial_sections3,
-                                       num_angular_sections3,
-                                       num_azimuthal_sections3, sphere_center3, sphere_max_radius3);
-        const BoundVec3 ray_origin3(10.0, 0.0, -13000.0);
-        const FreeVec3 ray_direction3(0.0, 0.0, 1.0);
-        const Ray ray3(ray_origin3, ray_direction3);
-        const double t_begin3 = 0.0;
-        const double t_end3 = 100000.0;
-        const auto actual_voxels3 = sphericalCoordinateVoxelTraversal(ray3, grid3, t_begin3, t_end3);
-    }
-}
-
-static void MultipleRayNoIntersection(benchmark::State& state) {
-    for (auto _ : state) {
-        const int number_of_runs = 50000;
-        const BoundVec3 min_bound5(0.0, 0.0, 0.0);
-        const BoundVec3 max_bound5(30.0, 30.0, 30.0);
-        const BoundVec3 sphere_center5(15.0, 15.0, 15.0);
-        const double sphere_max_radius5 = 10.0;
-        const std::size_t num_radial_sections5 = 4;
-        const std::size_t num_angular_sections5 = 8;
-        const std::size_t num_azimuthal_sections5 = 4;
-        const SphericalVoxelGrid grid5(min_bound5, max_bound5, num_radial_sections5,
-                                       num_angular_sections5,
-                                       num_azimuthal_sections5, sphere_center5, sphere_max_radius5);
-        const BoundVec3 ray_origin5(3.0, 3.0, 3.0);
-        const FreeVec3 ray_direction5(-2.0, -1.3, 1.0);
-        const Ray ray5(ray_origin5, ray_direction5);
-        const double t_begin5 = 0.0;
-        const double t_end5 = 15.0;
-        for (int i = 0; i < number_of_runs; ++i) { sphericalCoordinateVoxelTraversal(ray5, grid5, t_begin5, t_end5); }
-    }
-}
-
-static void MultipleRayIntersection(benchmark::State& state) {
-    for (auto _ : state) {
-        const int number_of_rays = 100;
-        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10000.0;
-        const std::size_t num_radial_sections = 10000;
-        const std::size_t num_angular_sections = 10000;
-        const std::size_t num_azimuthal_sections = 10000;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                      num_angular_sections,
-                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const double t_begin = 0.0;
-        const double t_end = 100000.0;
-
-        double ray_origin_x = -5000.0;
-        for (int i = 0; i < number_of_rays; ++i) {
-            const BoundVec3 ray_origin(ray_origin_x, 0.0, 0.0);
-            const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+namespace {
+    static void TraversalOne(benchmark::State &state) {
+        for (auto _ : state) {
+            // Traversal from bottom left to upper right.
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                          num_angular_sections,
+                                          num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const BoundVec3 ray_origin(-13000.0, -13000.0, -13000.0);
+            const FreeVec3 ray_direction(1.0, 1.0, 1.0);
             const Ray ray(ray_origin, ray_direction);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
             const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-            ray_origin_x += 100.0;
         }
     }
-}
 
-static void OrthographicRayTrace(benchmark::State& state) {
-    for (auto _ : state) {
-        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
-        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
-        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
-        const double sphere_max_radius = 10000.0;
-        const std::size_t num_radial_sections = 10000;
-        const std::size_t num_angular_sections = 10000;
-        const std::size_t num_azimuthal_sections = 10000;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
-                                      num_angular_sections,
-                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
-        const double t_begin = 0.0;
-        const double t_end = 100000.0;
+    static void TraversalTwo(benchmark::State &state) {
+        for (auto _ : state) {
+            // Traversal from upper right to bottom left.
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                          num_angular_sections,
+                                          num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const BoundVec3 ray_origin(13000.0, 13000.0, 13000.0);
+            const FreeVec3 ray_direction(-1.0, -1.0, -1.0);
+            const Ray ray(ray_origin, ray_direction);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
+            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+        }
+    }
 
-        double ray_origin_x = -5000.0;
-        double ray_origin_y = -5000.0;
-        for (int i = 0; i < 100; ++i) {
-            for (int j = 0; j < 100; ++j) {
-                const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, 0.0);
+    static void TraversalParallelX(benchmark::State &state) {
+        for (auto _ : state) {
+            const BoundVec3 min_bound4(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound4(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center4(0.0, 0.0, 0.0);
+            const double sphere_max_radius4 = 10000.0;
+            const std::size_t num_radial_sections4 = 10000;
+            const std::size_t num_angular_sections4 = 10000;
+            const std::size_t num_azimuthal_sections4 = 10000;
+            const SphericalVoxelGrid grid4(min_bound4, max_bound4, num_radial_sections4,
+                                           num_angular_sections4,
+                                           num_azimuthal_sections4, sphere_center4, sphere_max_radius4);
+            const BoundVec3 ray_origin4(-13000.0, 10.0, 10.0);
+            const FreeVec3 ray_direction4(1.0, 0.0, 0.0);
+            const Ray ray4(ray_origin4, ray_direction4);
+            const double t_begin4 = 0.0;
+            const double t_end4 = 100000.0;
+            const auto actual_voxels4 = sphericalCoordinateVoxelTraversal(ray4, grid4, t_begin4, t_end4);
+        }
+    }
+
+    static void TraversalParallelY(benchmark::State &state) {
+        for (auto _ : state) {
+            const BoundVec3 min_bound2(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound2(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center2(0.0, 0.0, 0.0);
+            const double sphere_max_radius2 = 10000.0;
+            const std::size_t num_radial_sections2 = 10000;
+            const std::size_t num_angular_sections2 = 10000;
+            const std::size_t num_azimuthal_sections2 = 10000;
+            const SphericalVoxelGrid grid2(min_bound2, max_bound2, num_radial_sections2,
+                                           num_angular_sections2,
+                                           num_azimuthal_sections2, sphere_center2, sphere_max_radius2);
+            const BoundVec3 ray_origin2(10.0, -13000.0, 0.0);
+            const FreeVec3 ray_direction2(0.0, 1.0, 0.0);
+            const Ray ray2(ray_origin2, ray_direction2);
+            const double t_begin2 = 0.0;
+            const double t_end2 = 100000.0;
+            const auto actual_voxels2 = sphericalCoordinateVoxelTraversal(ray2, grid2, t_begin2, t_end2);
+        }
+    }
+
+    static void TraversalParallelZ(benchmark::State &state) {
+        for (auto _ : state) {
+            const BoundVec3 min_bound3(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound3(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center3(0.0, 0.0, 0.0);
+            const double sphere_max_radius3 = 10000.0;
+            const std::size_t num_radial_sections3 = 10000;
+            const std::size_t num_angular_sections3 = 10000;
+            const std::size_t num_azimuthal_sections3 = 10000;
+            const SphericalVoxelGrid grid3(min_bound3, max_bound3, num_radial_sections3,
+                                           num_angular_sections3,
+                                           num_azimuthal_sections3, sphere_center3, sphere_max_radius3);
+            const BoundVec3 ray_origin3(10.0, 0.0, -13000.0);
+            const FreeVec3 ray_direction3(0.0, 0.0, 1.0);
+            const Ray ray3(ray_origin3, ray_direction3);
+            const double t_begin3 = 0.0;
+            const double t_end3 = 100000.0;
+            const auto actual_voxels3 = sphericalCoordinateVoxelTraversal(ray3, grid3, t_begin3, t_end3);
+        }
+    }
+
+    static void MultipleRayNoIntersection(benchmark::State &state) {
+        for (auto _ : state) {
+            const int number_of_runs = 50000;
+            const BoundVec3 min_bound5(0.0, 0.0, 0.0);
+            const BoundVec3 max_bound5(30.0, 30.0, 30.0);
+            const BoundVec3 sphere_center5(15.0, 15.0, 15.0);
+            const double sphere_max_radius5 = 10.0;
+            const std::size_t num_radial_sections5 = 4;
+            const std::size_t num_angular_sections5 = 8;
+            const std::size_t num_azimuthal_sections5 = 4;
+            const SphericalVoxelGrid grid5(min_bound5, max_bound5, num_radial_sections5,
+                                           num_angular_sections5,
+                                           num_azimuthal_sections5, sphere_center5, sphere_max_radius5);
+            const BoundVec3 ray_origin5(3.0, 3.0, 3.0);
+            const FreeVec3 ray_direction5(-2.0, -1.3, 1.0);
+            const Ray ray5(ray_origin5, ray_direction5);
+            const double t_begin5 = 0.0;
+            const double t_end5 = 15.0;
+            for (int i = 0; i < number_of_runs; ++i) {
+                sphericalCoordinateVoxelTraversal(ray5, grid5, t_begin5, t_end5);
+            }
+        }
+    }
+
+    static void MultipleRayIntersection(benchmark::State &state) {
+        for (auto _ : state) {
+            const int number_of_rays = 100;
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                          num_angular_sections,
+                                          num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
+
+            double ray_origin_x = -5000.0;
+            for (int i = 0; i < number_of_rays; ++i) {
+                const BoundVec3 ray_origin(ray_origin_x, 0.0, 0.0);
                 const FreeVec3 ray_direction(1.0, 0.0, 0.0);
                 const Ray ray(ray_origin, ray_direction);
                 const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
-                ray_origin_y += 100.0;
+                ray_origin_x += 100.0;
             }
-            ray_origin_x += 100.0;
         }
     }
-}
 
-BENCHMARK(TraversalOne)->Unit(benchmark::kMillisecond);
-BENCHMARK(TraversalTwo)->Unit(benchmark::kMillisecond);
-BENCHMARK(TraversalParallelX)->Unit(benchmark::kMillisecond);
-BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
-BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
-BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
-BENCHMARK(MultipleRayIntersection)->Unit(benchmark::kMillisecond);
-BENCHMARK(OrthographicRayTrace)->Unit(benchmark::kMillisecond);
+    static void OrthographicRayTrace(benchmark::State &state) {
+        for (auto _ : state) {
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                          num_angular_sections,
+                                          num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
+
+            double ray_origin_x = -5000.0;
+            double ray_origin_y = -5000.0;
+            for (int i = 0; i < 100; ++i) {
+                for (int j = 0; j < 100; ++j) {
+                    const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, 0.0);
+                    const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+                    const Ray ray(ray_origin, ray_direction);
+                    const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+                    ray_origin_y += 100.0;
+                }
+                ray_origin_x += 100.0;
+            }
+        }
+    }
+
+    BENCHMARK(TraversalOne)->Unit(benchmark::kMillisecond);
+    BENCHMARK(TraversalTwo)->Unit(benchmark::kMillisecond);
+    BENCHMARK(TraversalParallelX)->Unit(benchmark::kMillisecond);
+    BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
+    BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
+    BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
+    BENCHMARK(MultipleRayIntersection)->Unit(benchmark::kMillisecond);
+    BENCHMARK(OrthographicRayTrace)->Unit(benchmark::kMillisecond);
+}
 
 BENCHMARK_MAIN();

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -6,6 +6,7 @@
 // https://github.com/google/benchmark
 
 namespace {
+
     static void TraversalOne(benchmark::State &state) {
         for (auto _ : state) {
             // Traversal from bottom left to upper right.
@@ -16,7 +17,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                           num_angular_sections,
                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
             const BoundVec3 ray_origin(-13000.0, -13000.0, -13000.0);
@@ -38,7 +39,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                           num_angular_sections,
                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
             const BoundVec3 ray_origin(13000.0, 13000.0, 13000.0);
@@ -59,7 +60,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                            num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
             const BoundVec3 ray_origin(-13000.0, 10.0, 10.0);
@@ -80,7 +81,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                            num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
             const BoundVec3 ray_origin(10.0, -13000.0, 0.0);
@@ -101,7 +102,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                            num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
             const BoundVec3 ray_origin(10.0, 0.0, -13000.0);
@@ -123,7 +124,7 @@ namespace {
             const std::size_t num_radial_sections = 4;
             const std::size_t num_angular_sections = 8;
             const std::size_t num_azimuthal_sections = 4;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                            num_angular_sections,
                                            num_azimuthal_sections, sphere_center, sphere_max_radius);
             const BoundVec3 ray_origin(3.0, 3.0, 3.0);
@@ -147,7 +148,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                           num_angular_sections,
                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
             const double t_begin = 0.0;
@@ -173,7 +174,7 @@ namespace {
             const std::size_t num_radial_sections = 10000;
             const std::size_t num_angular_sections = 10000;
             const std::size_t num_azimuthal_sections = 10000;
-            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+            const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                           num_angular_sections,
                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
             const double t_begin = 0.0;
@@ -202,6 +203,7 @@ namespace {
     BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
     BENCHMARK(MultipleRayIntersection)->Unit(benchmark::kMillisecond);
     BENCHMARK(OrthographicRayTrace)->Unit(benchmark::kMillisecond);
-}
+
+} // namespace
 
 BENCHMARK_MAIN();

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -157,6 +157,36 @@ static void MultipleRayIntersection(benchmark::State& state) {
     }
 }
 
+static void OrthographicRayTrace(benchmark::State& state) {
+    for (auto _ : state) {
+        const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+        const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+        const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+        const double sphere_max_radius = 10000.0;
+        const std::size_t num_radial_sections = 10000;
+        const std::size_t num_angular_sections = 10000;
+        const std::size_t num_azimuthal_sections = 10000;
+        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                      num_angular_sections,
+                                      num_azimuthal_sections, sphere_center, sphere_max_radius);
+        const double t_begin = 0.0;
+        const double t_end = 100000.0;
+
+        double ray_origin_x = -5000.0;
+        double ray_origin_y = -5000.0;
+        for (int i = 0; i < 100; ++i) {
+            for (int j = 0; j < 100; ++j) {
+                const BoundVec3 ray_origin(ray_origin_x, ray_origin_y, 0.0);
+                const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+                const Ray ray(ray_origin, ray_direction);
+                const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
+                ray_origin_y += 100.0;
+            }
+            ray_origin_x += 100.0;
+        }
+    }
+}
+
 BENCHMARK(TraversalOne)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalTwo)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalParallelX)->Unit(benchmark::kMillisecond);
@@ -164,5 +194,6 @@ BENCHMARK(TraversalParallelY)->Unit(benchmark::kMillisecond);
 BENCHMARK(TraversalParallelZ)->Unit(benchmark::kMillisecond);
 BENCHMARK(MultipleRayNoIntersection)->Unit(benchmark::kMillisecond);
 BENCHMARK(MultipleRayIntersection)->Unit(benchmark::kMillisecond);
+BENCHMARK(OrthographicRayTrace)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/cpp/testing/SVR_benchmarks.cpp
+++ b/cpp/testing/SVR_benchmarks.cpp
@@ -52,87 +52,87 @@ namespace {
 
     static void TraversalParallelX(benchmark::State &state) {
         for (auto _ : state) {
-            const BoundVec3 min_bound4(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound4(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center4(0.0, 0.0, 0.0);
-            const double sphere_max_radius4 = 10000.0;
-            const std::size_t num_radial_sections4 = 10000;
-            const std::size_t num_angular_sections4 = 10000;
-            const std::size_t num_azimuthal_sections4 = 10000;
-            const SphericalVoxelGrid grid4(min_bound4, max_bound4, num_radial_sections4,
-                                           num_angular_sections4,
-                                           num_azimuthal_sections4, sphere_center4, sphere_max_radius4);
-            const BoundVec3 ray_origin4(-13000.0, 10.0, 10.0);
-            const FreeVec3 ray_direction4(1.0, 0.0, 0.0);
-            const Ray ray4(ray_origin4, ray_direction4);
-            const double t_begin4 = 0.0;
-            const double t_end4 = 100000.0;
-            const auto actual_voxels4 = sphericalCoordinateVoxelTraversal(ray4, grid4, t_begin4, t_end4);
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                           num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const BoundVec3 ray_origin(-13000.0, 10.0, 10.0);
+            const FreeVec3 ray_direction(1.0, 0.0, 0.0);
+            const Ray ray(ray_origin, ray_direction);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
+            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
         }
     }
 
     static void TraversalParallelY(benchmark::State &state) {
         for (auto _ : state) {
-            const BoundVec3 min_bound2(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound2(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center2(0.0, 0.0, 0.0);
-            const double sphere_max_radius2 = 10000.0;
-            const std::size_t num_radial_sections2 = 10000;
-            const std::size_t num_angular_sections2 = 10000;
-            const std::size_t num_azimuthal_sections2 = 10000;
-            const SphericalVoxelGrid grid2(min_bound2, max_bound2, num_radial_sections2,
-                                           num_angular_sections2,
-                                           num_azimuthal_sections2, sphere_center2, sphere_max_radius2);
-            const BoundVec3 ray_origin2(10.0, -13000.0, 0.0);
-            const FreeVec3 ray_direction2(0.0, 1.0, 0.0);
-            const Ray ray2(ray_origin2, ray_direction2);
-            const double t_begin2 = 0.0;
-            const double t_end2 = 100000.0;
-            const auto actual_voxels2 = sphericalCoordinateVoxelTraversal(ray2, grid2, t_begin2, t_end2);
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                           num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const BoundVec3 ray_origin(10.0, -13000.0, 0.0);
+            const FreeVec3 ray_direction(0.0, 1.0, 0.0);
+            const Ray ray(ray_origin, ray_direction);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
+            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
         }
     }
 
     static void TraversalParallelZ(benchmark::State &state) {
         for (auto _ : state) {
-            const BoundVec3 min_bound3(-20000.0, -20000.0, -20000.0);
-            const BoundVec3 max_bound3(20000.0, 20000.0, 20000.0);
-            const BoundVec3 sphere_center3(0.0, 0.0, 0.0);
-            const double sphere_max_radius3 = 10000.0;
-            const std::size_t num_radial_sections3 = 10000;
-            const std::size_t num_angular_sections3 = 10000;
-            const std::size_t num_azimuthal_sections3 = 10000;
-            const SphericalVoxelGrid grid3(min_bound3, max_bound3, num_radial_sections3,
-                                           num_angular_sections3,
-                                           num_azimuthal_sections3, sphere_center3, sphere_max_radius3);
-            const BoundVec3 ray_origin3(10.0, 0.0, -13000.0);
-            const FreeVec3 ray_direction3(0.0, 0.0, 1.0);
-            const Ray ray3(ray_origin3, ray_direction3);
-            const double t_begin3 = 0.0;
-            const double t_end3 = 100000.0;
-            const auto actual_voxels3 = sphericalCoordinateVoxelTraversal(ray3, grid3, t_begin3, t_end3);
+            const BoundVec3 min_bound(-20000.0, -20000.0, -20000.0);
+            const BoundVec3 max_bound(20000.0, 20000.0, 20000.0);
+            const BoundVec3 sphere_center(0.0, 0.0, 0.0);
+            const double sphere_max_radius = 10000.0;
+            const std::size_t num_radial_sections = 10000;
+            const std::size_t num_angular_sections = 10000;
+            const std::size_t num_azimuthal_sections = 10000;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                           num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const BoundVec3 ray_origin(10.0, 0.0, -13000.0);
+            const FreeVec3 ray_direction(0.0, 0.0, 1.0);
+            const Ray ray(ray_origin, ray_direction);
+            const double t_begin = 0.0;
+            const double t_end = 100000.0;
+            const auto actual_voxels = sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
         }
     }
 
     static void MultipleRayNoIntersection(benchmark::State &state) {
         for (auto _ : state) {
             const int number_of_runs = 50000;
-            const BoundVec3 min_bound5(0.0, 0.0, 0.0);
-            const BoundVec3 max_bound5(30.0, 30.0, 30.0);
-            const BoundVec3 sphere_center5(15.0, 15.0, 15.0);
-            const double sphere_max_radius5 = 10.0;
-            const std::size_t num_radial_sections5 = 4;
-            const std::size_t num_angular_sections5 = 8;
-            const std::size_t num_azimuthal_sections5 = 4;
-            const SphericalVoxelGrid grid5(min_bound5, max_bound5, num_radial_sections5,
-                                           num_angular_sections5,
-                                           num_azimuthal_sections5, sphere_center5, sphere_max_radius5);
-            const BoundVec3 ray_origin5(3.0, 3.0, 3.0);
-            const FreeVec3 ray_direction5(-2.0, -1.3, 1.0);
-            const Ray ray5(ray_origin5, ray_direction5);
-            const double t_begin5 = 0.0;
-            const double t_end5 = 15.0;
+            const BoundVec3 min_bound(0.0, 0.0, 0.0);
+            const BoundVec3 max_bound(30.0, 30.0, 30.0);
+            const BoundVec3 sphere_center(15.0, 15.0, 15.0);
+            const double sphere_max_radius = 10.0;
+            const std::size_t num_radial_sections = 4;
+            const std::size_t num_angular_sections = 8;
+            const std::size_t num_azimuthal_sections = 4;
+            const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+                                           num_angular_sections,
+                                           num_azimuthal_sections, sphere_center, sphere_max_radius);
+            const BoundVec3 ray_origin(3.0, 3.0, 3.0);
+            const FreeVec3 ray_direction(-2.0, -1.3, 1.0);
+            const Ray ray(ray_origin, ray_direction);
+            const double t_begin = 0.0;
+            const double t_end = 15.0;
             for (int i = 0; i < number_of_runs; ++i) {
-                sphericalCoordinateVoxelTraversal(ray5, grid5, t_begin5, t_end5);
+                sphericalCoordinateVoxelTraversal(ray, grid, t_begin, t_end);
             }
         }
     }

--- a/cpp/testing/SVR_tests.cpp
+++ b/cpp/testing/SVR_tests.cpp
@@ -14,8 +14,9 @@
 // For examples of Google Test, see: https://github.com/google/googletest/tree/master/googletest/samples
 
 namespace {
+
     // Determines equality amongst actual spherical voxels, and the expected spherical voxels.
-    void expectEqualVoxels(const std::vector<SphericalVoxel>& actual_voxels,
+    void expectEqualVoxels(const std::vector<SVR::SphericalVoxel>& actual_voxels,
                            const std::vector<int>& expected_radial_voxels,
                            const std::vector<int>& expected_theta_voxels,
                            const std::vector<int>& expected_phi_voxels) {
@@ -24,11 +25,11 @@ namespace {
         std::vector<int> theta_voxels(num_voxels);
         std::vector<int> phi_voxels(num_voxels);
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), radial_voxels.begin(),
-                       [](const SphericalVoxel& sv) -> int { return sv.radial_voxel; });
+                       [](const SVR::SphericalVoxel& sv) -> int { return sv.radial_voxel; });
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), theta_voxels.begin(),
-                       [](const SphericalVoxel& sv) -> int { return sv.angular_voxel; });
+                       [](const SVR::SphericalVoxel& sv) -> int { return sv.angular_voxel; });
         std::transform(actual_voxels.cbegin(), actual_voxels.cend(), phi_voxels.begin(),
-                       [](const SphericalVoxel& sv) -> int { return sv.azimuthal_voxel; });
+                       [](const SVR::SphericalVoxel& sv) -> int { return sv.azimuthal_voxel; });
         EXPECT_THAT(radial_voxels, testing::ContainerEq(expected_radial_voxels));
         EXPECT_THAT(theta_voxels, testing::ContainerEq(expected_theta_voxels));
         EXPECT_THAT(phi_voxels, testing::ContainerEq(expected_phi_voxels));
@@ -42,7 +43,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(3.0, 3.0, 3.0);
@@ -63,7 +64,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
@@ -87,7 +88,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections, num_azimuthal_sections,
                                       sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, -13.0, -13.0);
@@ -112,7 +113,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, 0.0, 0.0);
@@ -136,7 +137,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(0.0, -15.0, 0.0);
@@ -160,7 +161,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 8;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(0.0, 0.0, -15.0);
@@ -184,7 +185,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, -15.0, 0.0);
@@ -208,7 +209,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-15.0, 0.0, -15.0);
@@ -232,7 +233,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections,
                                       num_azimuthal_sections, sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(0.0, -15.0, -15.0);
@@ -256,7 +257,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections, num_azimuthal_sections,
                                       sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(13.0, -15.0, -15.0);
@@ -280,7 +281,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections, num_azimuthal_sections,
                                       sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, 17.0, -15.0);
@@ -304,7 +305,7 @@ namespace {
         const std::size_t num_radial_sections = 4;
         const std::size_t num_angular_sections = 4;
         const std::size_t num_azimuthal_sections = 4;
-        const SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
+        const SVR::SphericalVoxelGrid grid(min_bound, max_bound, num_radial_sections,
                                       num_angular_sections, num_azimuthal_sections,
                                       sphere_center, sphere_max_radius);
         const BoundVec3 ray_origin(-13.0, -12.0, 15.3);
@@ -319,4 +320,5 @@ namespace {
         const std::vector<int> expected_phi_voxels = {1, 1, 1, 0, 0};
         expectEqualVoxels(actual_voxels, expected_radial_voxels, expected_theta_voxels, expected_phi_voxels);
     }
-}
+
+} // namespace

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -34,6 +34,15 @@ public:
         return x() * x() + y() * y() + z() * z();
     }
 
+  inline double operator[](const std::size_t index) const noexcept {
+      switch(index) {
+        case 0: return this->x();
+        case 1: return this->y();
+        case 2: return this->z();
+      }
+      return -1;
+  }
+
 private:
     // Represents the x-dimension value of the vector.
     double x_;

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -174,6 +174,15 @@ struct UnitVec3 {
 
     inline const FreeVec3 &to_free() const noexcept { return inner_; }
 
+    inline double operator[](const std::size_t index) const noexcept {
+      switch(index) {
+        case 0: return this->x();
+        case 1: return this->y();
+        case 2: return this->z();
+      }
+      return -1;
+    }
+
 private:
     const FreeVec3 inner_;
 };

--- a/cpp/vec3.h
+++ b/cpp/vec3.h
@@ -27,20 +27,20 @@ public:
     inline double &z() noexcept { return this->z_; }
 
     inline double length() const noexcept {
-        return std::sqrt(this->x() * this->x() + this->y() * this->y() + this->z() * this->z());
+        return std::sqrt(this->x_ * this->x_ + this->y_ * this->y_ + this->z_ * this->z_);
     }
 
     inline double squared_length() const noexcept {
-        return x() * x() + y() * y() + z() * z();
+        return x_ * x_ + y_ * y_ + z_ * z_;
     }
 
   inline double operator[](const std::size_t index) const noexcept {
       switch(index) {
-        case 0: return this->x();
-        case 1: return this->y();
-        case 2: return this->z();
+        case 0: return this->x_;
+        case 1: return this->y_;
+        case 2: return this->z_;
       }
-      return -1;
+      return NAN;
   }
 
 private:
@@ -180,7 +180,7 @@ struct UnitVec3 {
         case 1: return this->y();
         case 2: return this->z();
       }
-      return -1;
+      return NAN;
     }
 
 private:


### PR DESCRIPTION
- Add namespaces to avoid naming collisions.
- Optimize timeOfIntersectionAt() to avoid branch prediction slowdowns. Upon construction, a non-zero direction is determined.
- Add [] operator to Vec3.
- Remove unnecessary fluff in CMake.
- Add orthographic ray trace benchmark.
- Other cleanup.